### PR TITLE
Add shadowvolume component for VSS snapshot file access

### DIFF
--- a/06-shadowvolume.c.md
+++ b/06-shadowvolume.c.md
@@ -93,3 +93,37 @@ Run it from an elevated prompt (enumerating `\Device` and using the backup privi
 ```
 
 The demo enables the backup privilege, lists the shadow copy devices, opens `System.evtx` inside the first snapshot and prints its 8 byte header - which reads `ElfFile`, the event log magic - to prove the read came from inside the snapshot.
+
+## Memory mapping a file and changing its bytes
+
+`map` builds a file-backed section with `NtCreateSection` and maps a read/write view with `NtMapViewOfSection`:
+
+```c
+struct mapping view = shadowvolume.map( file, size );  // size 0 = whole file, else extend to size
+wmemcpy( view.base, source, chars );                   // just write into the view
+shadowvolume.flush( view );                            // NtFlushVirtualMemory -> disk
+shadowvolume.unmap( view );                            // NtUnmapViewOfSection + close the section
+```
+
+Passing a `size` larger than the file makes `NtCreateSection` extend the file to fit, so you can create an empty file and let the section size it. `struct mapping` keeps the section handle alongside the view so `unmap` can close both.
+
+Because a shadow copy is read only, the demo's writable mapping targets a scratch file under `%TEMP%` reached through the `\??\` prefix (the NT symlink onto the Win32 drive letters). It expands `%comspec%`, writes those bytes into the mapped view, flushes and closes - the file on disk ends up holding the comspec path.
+
+## Finding and running a file inside the snapshot
+
+`open` now asks for `MAXIMUM_ALLOWED` instead of a fixed read mask, so the object manager grants every right the token is allowed on the object - a read only snapshot still yields read, a writable volume yields everything.
+
+`find` opens `<device>\Windows` as a directory and calls `NtQueryDirectoryFile` with the filename as a single-entry mask; a hit means the file exists, and it returns an open handle plus the full NT path:
+
+```c
+wchar_t path[ 1024 ];
+HANDLE hh = shadowvolume.find( L"\\Device\\HarddiskVolumeShadowCopy1", L"hh.exe", path, ARRAYSIZE(path) );
+```
+
+`run` launches it with the native `RtlCreateUserProcess` - it sections the image straight from the snapshot path, so the process runs the copy inside the shadow copy rather than the live `\Windows\hh.exe`:
+
+```c
+HANDLE process = shadowvolume.run( path );  // RtlCreateProcessParametersEx + RtlCreateUserProcess + NtResumeThread
+```
+
+`RtlCreateUserProcess` creates the process suspended, so `run` resumes the initial thread before returning the process handle. The process parameters are built with `NULL` desktop/environment fields; a GUI child like `hh.exe` may want an explicit desktop, which you would pass to `RtlCreateProcessParametersEx`.

--- a/06-shadowvolume.c.md
+++ b/06-shadowvolume.c.md
@@ -1,0 +1,95 @@
+# Opening a file on a shadow volume with the NT API
+
+`shadowvolume.c` is a small component in the same style as the rest of this repository - a public interface at the top of the file, the private implementation below the `__INCLUDE_LEVEL__ == 0` guard. It opens and reads a file that lives inside a Volume Shadow Copy (a VSS snapshot) by talking to the native NT API directly instead of the Win32 layer.
+
+## Why the NT API and not `CreateFile`
+
+A shadow copy is published by the `volsnap` driver as a device object named:
+
+```
+\Device\HarddiskVolumeShadowCopyN
+```
+
+It has no drive letter and no DOS device name, so `CreateFileW` cannot reach it as it is - the closest you can get from Win32 is the `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopyN\...` escape hatch, which just tells the Win32 layer to stop rewriting the path and hand it to the object manager verbatim.
+
+The NT API names kernel objects directly, so there is nothing to escape. `NtOpenFile` takes an `OBJECT_ATTRIBUTES` whose `ObjectName` is a full NT path, and the device path plus the in-volume file path *is* that name:
+
+```
+\Device\HarddiskVolumeShadowCopy1\Windows\System32\winevt\Logs\System.evtx
+```
+
+That is the whole idea of the example - the snapshot device and the file inside it are joined into one `UNICODE_STRING` and opened in a single call.
+
+## The interface
+
+```c
+extern const struct shadowvolume{
+    HANDLE   (*open)( const wchar_t* device, const wchar_t* path );
+    uint32_t (*read)( HANDLE file, void* buffer, uint32_t bytes, uint64_t offset );
+    void     (*close)( HANDLE file );
+    uint32_t (*for_each_device)( void(*found)( const wchar_t* device ) );
+    bool     (*enable_backup_privilege)( void );
+    long     (*last_status)( void );
+}shadowvolume;
+```
+
+- `open` joins `device` and `path` and calls `NtOpenFile`.
+- `read` is `NtReadFile` with an explicit byte offset, so the caller does not depend on a file pointer.
+- `for_each_device` enumerates `\Device` through `NtQueryDirectoryObject` and reports every `HarddiskVolumeShadowCopyN` that currently exists, so you do not have to guess `N`.
+- `enable_backup_privilege` turns on `SeBackupPrivilege` in the current token, which is what lets you read another user's files inside the snapshot.
+- `last_status` returns the `NTSTATUS` of the previous call - negative is failure.
+
+## Binding ntdll at runtime
+
+The native functions are not in an import library you would normally link, so the component resolves them from the already-mapped `ntdll.dll` on first use:
+
+```c
+const HMODULE ntdll = GetModuleHandleW( L"ntdll.dll" );  // always loaded, never LoadLibrary
+#define bind(function) ( nt.function = (typeof(nt.function))GetProcAddress( ntdll, #function ) )
+return  bind(NtOpenFile) && bind(NtReadFile) && bind(NtClose) &&
+        bind(NtOpenDirectoryObject) && bind(NtQueryDirectoryObject) && bind(RtlAdjustPrivilege);
+```
+
+`typeof(nt.function)` reuses the field's own type as the cast, so the pointer type is written exactly once - in the struct - the same trick used elsewhere in this repo with `typeof(console)` and `typeof(timers)`.
+
+## The types
+
+If you build against `<winternl.h>` or the WDK, the NT structures already exist. To keep the example self contained it declares `UNICODE_STRING`, `OBJECT_ATTRIBUTES` and `IO_STATUS_BLOCK` itself, guarded by `!defined(_WINTERNL_) && !defined(_NTDEF_)` so it does not clash if you do pull those headers in.
+
+`UNICODE_STRING` carries an explicit byte `Length`, so it never depends on a terminator - `nt_path` fills that in while still keeping the buffer zero terminated so it stays printable. Note `Length` is a `USHORT`, which is why the builder refuses a path over `0xFFFE` bytes.
+
+## Opening
+
+```c
+OBJECT_ATTRIBUTES attributes = {
+    .Length     = sizeof(attributes),
+    .ObjectName = &objectname,
+    .Attributes = OBJ_CASE_INSENSITIVE
+};
+status = nt.NtOpenFile(
+    &file,
+    FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+    &attributes,
+    &iostatus,
+    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+    FILE_SYNCHRONOUS_IO_NONALERT | FILE_NON_DIRECTORY_FILE | FILE_OPEN_FOR_BACKUP_INTENT
+);
+```
+
+- `FILE_SYNCHRONOUS_IO_NONALERT` gives the handle its own file pointer and makes `NtReadFile` block, so the code stays straight-line.
+- `FILE_OPEN_FOR_BACKUP_INTENT` is the native form of `FILE_FLAG_BACKUP_SEMANTICS`; paired with `SeBackupPrivilege` it lets a backup operator read files the ACL would otherwise deny.
+- A shadow copy is read only, so only read access and no write disposition is requested.
+
+## Trying it
+
+```
+clang -DSHADOWVOLUME_MAIN shadowvolume.c -o shadowvolume.exe
+```
+
+Run it from an elevated prompt (enumerating `\Device` and using the backup privilege both need it). Create a snapshot first if you have none, e.g. from an admin PowerShell:
+
+```
+(Get-WmiObject -List Win32_ShadowCopy).Create("C:\", "ClientAccessible")
+```
+
+The demo enables the backup privilege, lists the shadow copy devices, opens `System.evtx` inside the first snapshot and prints its 8 byte header - which reads `ElfFile`, the event log magic - to prove the read came from inside the snapshot.

--- a/07-shadowvolume.ps1.md
+++ b/07-shadowvolume.ps1.md
@@ -1,0 +1,133 @@
+# Can the shadow volume code be done in PowerShell?
+
+A fair question to ask about `shadowvolume.c` - it opens files inside a Volume Shadow Copy through the native NT API, does any of that actually need a compiled C program? The answer is no: PowerShell reaches every one of those calls. `shadowvolume.ps1` is the companion that shows it, and it turns out there are two honest answers.
+
+## The easy way: GLOBALROOT + WMI
+
+Most of the C example exists to solve one problem - a shadow copy is a device object named `\Device\HarddiskVolumeShadowCopyN` with no drive letter, so `CreateFileW` cannot reach it. The C article mentions the Win32 escape hatch and then deliberately walks past it. PowerShell can just take it:
+
+```powershell
+$sc = Get-CimInstance -ClassName Win32_ShadowCopy | Select-Object -First 1
+# $sc.DeviceObject is \\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1
+$bytes = [System.IO.File]::ReadAllBytes( "$($sc.DeviceObject)\Windows\System32\winevt\Logs\System.evtx" )
+```
+
+`Win32_ShadowCopy` hands you the device name so you never guess `N`, and `\\?\GLOBALROOT` tells the Win32 layer to stop rewriting the path and pass it to the object manager verbatim. `[System.IO.File]` then reads it like any other file. Three lines, no P/Invoke.
+
+That is the whole point the C article was making, from the other side: the `\\?\GLOBALROOT` prefix works *because* it drops down to the object manager - it is the same NT name, wrapped so the Win32 layer will carry it. PowerShell gets it for free because it stands on top of the Win32 layer. It also means you never left that layer, which is exactly what the C example set out to avoid.
+
+Enabling `SeBackupPrivilege` - what lets you read another user's files inside the snapshot - is the one piece the easy way cannot do on its own; there is no Win32 cmdlet for it, so even the easy path drops to the native `RtlAdjustPrivilege`. Which leads to the second answer.
+
+## The faithful way: P/Invoke into ntdll
+
+To actually do what the C file does - name the object directly, no GLOBALROOT wrapper - PowerShell calls the same ntdll exports. You declare them once with `Add-Type`:
+
+```powershell
+Add-Type -Namespace Nt -Name Native -MemberDefinition @'
+    [DllImport("ntdll.dll")] public static extern int NtOpenFile(
+        out IntPtr handle, uint access, ref OBJECT_ATTRIBUTES attributes,
+        out IO_STATUS_BLOCK iostatus, uint share, uint options );
+    // ... NtReadFile, NtClose, NtQueryDirectoryObject, RtlAdjustPrivilege, NtCreateSection, ...
+'@
+```
+
+Here is a genuine win over the C version. `shadowvolume.c` cannot link an import library for these, so it resolves them by hand:
+
+```c
+const HMODULE ntdll = GetModuleHandleW( L"ntdll.dll" );
+#define bind(function) ( nt.function = (typeof(nt.function))GetProcAddress( ntdll, #function ) )
+```
+
+`[DllImport("ntdll.dll")]` *is* that binding. The CLR resolves the export the first time the method is called, so the whole `bind_ntdll()` scaffolding - the function-pointer struct, the `GetProcAddress` loop, the "is it bound yet" guard - simply does not exist in the PowerShell version. You name the function once, in the `DllImport`, and call it.
+
+## The interface
+
+The C file is a `struct shadowvolume` of function pointers, filled in at the bottom of the file so the private implementation stays private. The natural PowerShell parallel is a `[pscustomobject]` whose members are `ScriptMethod`s, assembled in one place:
+
+```powershell
+$shadowvolume = [pscustomobject]@{}
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name Open -Value { param($Device,$Path) ... }
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name Read -Value { param($File,$Bytes,$Offset) ... }
+# Close, ForEachDevice, EnableBackupPrivilege, OpenWritable, Map, Flush, Unmap, Find, LastStatus
+```
+
+Same shape, same verbs - a value you pass around whose methods are the only way in. The vtable the C file fills at link time becomes a bag of script blocks you attach at load time.
+
+## The types
+
+`NtOpenFile` needs `UNICODE_STRING`, `OBJECT_ATTRIBUTES` and `IO_STATUS_BLOCK`, and they are not in any reference assembly, so - exactly like the C file declaring them when you do not include `<winternl.h>` - you declare them in the `Add-Type` block:
+
+```csharp
+[StructLayout(LayoutKind.Sequential)]
+public struct UNICODE_STRING {
+    public ushort Length;           // in bytes, without the terminator
+    public ushort MaximumLength;
+    public IntPtr Buffer;           // a pinned wchar_t*
+}
+```
+
+`[StructLayout(LayoutKind.Sequential)]` is the C# way to say "lay these fields out in order, like a C struct". The catch PowerShell adds is that you manage the memory yourself: the NT path has to be a real `wchar_t*` that stays put across the call, so you pin it:
+
+```powershell
+$buffer = [Runtime.InteropServices.Marshal]::StringToHGlobalUni( $joined )   # wchar_t*, zero terminated
+$us.Length = [ushort]( $joined.Length * 2 )                                   # bytes, like the C USHORT
+```
+
+That byte `Length` is the same detail the C article calls out - it is a `USHORT`, so a path over `0xFFFE` bytes is refused - and the PowerShell builder refuses it for the same reason.
+
+## Opening and reading
+
+Once the types are in place the call is a transcription of the C. Same access mask, same flags:
+
+```powershell
+[Nt.Native]::NtOpenFile(
+    [ref] $handle,
+    $NT.MAXIMUM_ALLOWED -bor $NT.SYNCHRONIZE,
+    [ref] $oa, [ref] $iostatus,
+    $NT.FILE_SHARE_READ -bor $NT.FILE_SHARE_WRITE -bor $NT.FILE_SHARE_DELETE,
+    $NT.FILE_SYNCHRONOUS_IO_NONALERT -bor $NT.FILE_NON_DIRECTORY_FILE -bor $NT.FILE_OPEN_FOR_BACKUP_INTENT )
+```
+
+`MAXIMUM_ALLOWED` hands back read on a read-only snapshot and everything on a writable volume, `FILE_OPEN_FOR_BACKUP_INTENT` paired with the backup privilege reads past the ACL, and `FILE_SYNCHRONOUS_IO_NONALERT` gives the handle its own file pointer so `NtReadFile` blocks - identical to the C, because it is the same function.
+
+## Mapping and find
+
+`Map` is `NtCreateSection` + `NtMapViewOfSection` with `PAGE_READWRITE` and `SEC_COMMIT`, and passing a size larger than the file extends it to fit, same as the C. The one PowerShell difference is how you touch the mapped view: C writes straight into `view.base` with `wmemcpy`, PowerShell has no raw pointer, so it copies through the marshaller:
+
+```powershell
+[System.Runtime.InteropServices.Marshal]::Copy( $bytes, 0, $view.Base, $view.Size )
+```
+
+`Find` opens `<device>\Windows` as a directory and calls `NtQueryDirectoryFile` with the filename as a single-entry mask - a hit means the file is there, and it returns the full NT path.
+
+`Run` is the last verb in the C file - `RtlCreateProcessParametersEx` + `RtlCreateUserProcess` + `NtResumeThread` to launch the copy that lives inside the snapshot. It is reachable from PowerShell the same way, but the marshalling is heavy: `RTL_USER_PROCESS_INFORMATION` with its embedded `SECTION_IMAGE_INFORMATION`, and process parameters that have to outlive the call. The shape is:
+
+```powershell
+[Nt.Native]::RtlCreateProcessParametersEx( [ref] $parameters, [ref] $image, ... )
+[Nt.Native]::RtlCreateUserProcess( [ref] $image, $OBJ_CASE_INSENSITIVE, $parameters, ..., [ref] $information )
+[Nt.Native]::NtResumeThread( $information.ThreadHandle, [IntPtr]::Zero )
+```
+
+`shadowvolume.ps1` ports the core faithfully and stops `run` at this sketch - the point of the exercise is that every call is reachable, and by `find` that point is made.
+
+## Trying it
+
+Same as the C demo: run it elevated (enumerating `\Device` and the backup privilege both need it), and create a snapshot first if you have none:
+
+```powershell
+(Get-WmiObject -List Win32_ShadowCopy).Create("C:\", "ClientAccessible")
+.\shadowvolume.ps1
+```
+
+It enables the backup privilege, lists the shadow copy devices, reads the 8-byte `System.evtx` header - which prints `ElfFile`, the event log magic - maps a scratch file under `%TEMP%` and writes `%comspec%` into it, then locates `hh.exe` in the snapshot. Dot-source it instead (`. .\shadowvolume.ps1`) and the demo does not run - you just get the `$shadowvolume` object - which is the PowerShell version of the C file's `__INCLUDE_LEVEL__ == 0` / `-DSHADOWVOLUME_MAIN` split between "included as a component" and "compiled as a program".
+
+## What PowerShell costs you
+
+So, yes - all of it can be done in PowerShell, and the easy path is genuinely three lines. The faithful port is not three lines, and it is worth being honest about why:
+
+- **Manual memory.** Every `UNICODE_STRING` buffer is an `AllocHGlobal` / `StringToHGlobalUni` you have to free. C's `wchar_t buffer[1024]` on the stack becomes a heap allocation with a `finally` to release it.
+- **No `typeof` trick.** The C file writes each pointer type exactly once and reuses it with `typeof(nt.function)`; the PowerShell version spells out every `DllImport` signature by hand.
+- **A compile on first run.** `Add-Type` compiles the C# block the first time the script loads - a one-time cost the C binary paid at build time.
+- **Marshalling in the way.** No raw pointers means `Marshal.Copy` and `PtrToStructure` everywhere the C just dereferences.
+
+But under all of it, the calls are byte-for-byte the same `NtOpenFile`, `NtReadFile` and `RtlAdjustPrivilege`. The NT API does not know or care that a script is calling it - which was the thing worth finding out.

--- a/coope.vcxproj
+++ b/coope.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="drawable.c" />
     <ClCompile Include="drawables.c" />
     <ClCompile Include="main.c" />
+    <ClCompile Include="shadowvolume.c" />
     <ClCompile Include="string.c" />
     <ClCompile Include="test.c" />
     <ClCompile Include="timer.c" />

--- a/shadowvolume.c
+++ b/shadowvolume.c
@@ -1,0 +1,231 @@
+#include "stdafx.h"
+#ifndef shadowvolume
+#	define shadowvolume shadowvolume
+	/*	A shadow copy is exposed by volsnap as a device object named
+		\Device\HarddiskVolumeShadowCopyN - it has no drive letter and no dos device name,
+		so it is not reachable through the win32 namespace without the \\?\GLOBALROOT escape.
+		The nt api names objects directly, so we can just open the device relative path as it is. */
+	extern const struct shadowvolume{
+		/*	device is the shadow copy device, path is the file inside it:
+			shadowvolume.open( L"\\Device\\HarddiskVolumeShadowCopy1", L"\\Windows\\System32\\winevt\\Logs\\System.evtx" ) */
+		HANDLE(*open)( const wchar_t* device, const wchar_t* path );
+		uint32_t(*read)( HANDLE file, void* buffer, uint32_t bytes, uint64_t offset );
+		void(*close)( HANDLE file );
+		/*	walks \Device and reports every HarddiskVolumeShadowCopyN currently present, returns the count */
+		uint32_t(*for_each_device)( void(*found)( const wchar_t* device ) );
+		/*	reading other users files inside the snapshot needs SeBackupPrivilege enabled in the token */
+		bool(*enable_backup_privilege)( void );
+		/*	the NTSTATUS of the last call, negative means failure */
+		long(*last_status)( void );
+	}shadowvolume;
+#	if __INCLUDE_LEVEL__ == 0
+		/*	the nt types are not in Windows.h - if you include <winternl.h> or the wdk headers
+			instead, drop this block, the guards below detect both of them. */
+#		if !defined(_WINTERNL_) && !defined(_NTDEF_)
+			typedef struct _UNICODE_STRING{
+				USHORT Length;			/* in bytes, not characters, and without the terminator */
+				USHORT MaximumLength;	/* in bytes, including room for a terminator */
+				PWSTR  Buffer;
+			}UNICODE_STRING, *PUNICODE_STRING;
+			typedef struct _OBJECT_ATTRIBUTES{
+				ULONG			Length;
+				HANDLE			RootDirectory;
+				PUNICODE_STRING	ObjectName;
+				ULONG			Attributes;
+				PVOID			SecurityDescriptor;
+				PVOID			SecurityQualityOfService;
+			}OBJECT_ATTRIBUTES, *POBJECT_ATTRIBUTES;
+			typedef struct _IO_STATUS_BLOCK{
+				union{
+					NTSTATUS	Status;
+					PVOID		Pointer;
+				};
+				ULONG_PTR		Information;	/* bytes transferred for read/write */
+			}IO_STATUS_BLOCK, *PIO_STATUS_BLOCK;
+#		endif
+		typedef struct _OBJECT_DIRECTORY_INFORMATION{
+			UNICODE_STRING Name;
+			UNICODE_STRING TypeName;
+		}OBJECT_DIRECTORY_INFORMATION;
+
+#		define OBJ_CASE_INSENSITIVE			0x00000040ul
+#		define FILE_OPEN					0x00000001ul	/* CreateDisposition: fail if it is not there */
+#		define FILE_SYNCHRONOUS_IO_NONALERT	0x00000020ul	/* the handle keeps its own file pointer, NtReadFile blocks */
+#		define FILE_NON_DIRECTORY_FILE		0x00000040ul
+#		define FILE_OPEN_FOR_BACKUP_INTENT	0x00004000ul	/* pairs with SeBackupPrivilege, like FILE_FLAG_BACKUP_SEMANTICS */
+#		define DIRECTORY_QUERY				0x00000001ul
+#		define STATUS_NO_MORE_ENTRIES		0x8000001Al
+#		define STATUS_INVALID_PARAMETER		0xC000000Dl
+#		define SE_BACKUP_PRIVILEGE			17ul
+
+		static struct{
+			NTSTATUS(NTAPI* NtOpenFile)( HANDLE*, ACCESS_MASK, OBJECT_ATTRIBUTES*, IO_STATUS_BLOCK*, ULONG share, ULONG options );
+			NTSTATUS(NTAPI* NtReadFile)( HANDLE, HANDLE event, PVOID apc, PVOID apccontext, IO_STATUS_BLOCK*, PVOID buffer, ULONG length, LARGE_INTEGER* offset, ULONG* key );
+			NTSTATUS(NTAPI* NtClose)( HANDLE );
+			NTSTATUS(NTAPI* NtOpenDirectoryObject)( HANDLE*, ACCESS_MASK, OBJECT_ATTRIBUTES* );
+			NTSTATUS(NTAPI* NtQueryDirectoryObject)( HANDLE, PVOID buffer, ULONG length, BOOLEAN singleentry, BOOLEAN restart, ULONG* context, ULONG* returnlength );
+			NTSTATUS(NTAPI* RtlAdjustPrivilege)( ULONG privilege, BOOLEAN enable, BOOLEAN thisthreadonly, BOOLEAN* wasenabled );
+		}nt;
+		static NTSTATUS status;
+
+		static bool bind_ntdll( void ){
+			if( nt.NtOpenFile ){ return true; }
+			const HMODULE ntdll = GetModuleHandleW( L"ntdll.dll" );	/* always mapped, never needs LoadLibrary */
+			if( ntdll == 0 ){ return false; }
+#			define bind(function) ( nt.function = (typeof(nt.function))GetProcAddress( ntdll, #function ) )
+			return	bind(NtOpenFile) &&
+					bind(NtReadFile) &&
+					bind(NtClose) &&
+					bind(NtOpenDirectoryObject) &&
+					bind(NtQueryDirectoryObject) &&
+					bind(RtlAdjustPrivilege);
+#			undef bind
+		}
+		/*	joins \Device\HarddiskVolumeShadowCopyN and \some\file into one nt object path,
+			a UNICODE_STRING carries its length so it is never terminator dependent, but we
+			keep it zero terminated anyway to stay printable. */
+		static bool nt_path( UNICODE_STRING* out, wchar_t* buffer, size_t characters, const wchar_t* device, const wchar_t* path ){
+			const size_t devicelength = device ? wcslen( device ) : 0;
+			const size_t pathlength = path ? wcslen( path ) : 0;
+			const bool separator = ( pathlength != 0 ) && ( path[0] != L'\\' ) && ( device[ devicelength - 1 ] != L'\\' );
+			const size_t total = devicelength + separator + pathlength;
+			if( ( devicelength == 0 ) || ( total + 1 > characters ) || ( total * sizeof(wchar_t) > 0xfffe ) ){
+				return false;	/* Length is an USHORT, a path can never be longer than that */
+			}
+			wmemcpy( buffer, device, devicelength );
+			if( separator ){ buffer[ devicelength ] = L'\\'; }
+			wmemcpy( buffer + devicelength + separator, path, pathlength );
+			buffer[ total ] = 0;
+			*out = (UNICODE_STRING){
+				.Length			= (USHORT)( total * sizeof(wchar_t) ),
+				.MaximumLength	= (USHORT)( ( total + 1 ) * sizeof(wchar_t) ),
+				.Buffer			= buffer
+			};
+			return true;
+		}
+		static HANDLE open( const wchar_t* device, const wchar_t* path ){
+			wchar_t pathbuffer[ 1024 ];
+			UNICODE_STRING objectname;
+			if( ! bind_ntdll() || ! nt_path( &objectname, pathbuffer, ARRAYSIZE(pathbuffer), device, path ) ){
+				status = STATUS_INVALID_PARAMETER;
+				return 0;
+			}
+			OBJECT_ATTRIBUTES attributes = {
+				.Length		= sizeof(attributes),
+				.ObjectName	= &objectname,
+				.Attributes	= OBJ_CASE_INSENSITIVE
+			};
+			HANDLE file = 0;
+			IO_STATUS_BLOCK iostatus = {};
+			status = nt.NtOpenFile(
+				&file,
+				FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+				&attributes,
+				&iostatus,
+				FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+				FILE_SYNCHRONOUS_IO_NONALERT | FILE_NON_DIRECTORY_FILE | FILE_OPEN_FOR_BACKUP_INTENT
+			);
+			return status >= 0 ? file : 0;
+		}
+		static uint32_t read( HANDLE file, void* buffer, uint32_t bytes, uint64_t offset ){
+			if( ! bind_ntdll() ){ return 0; }
+			IO_STATUS_BLOCK iostatus = {};
+			LARGE_INTEGER position = { .QuadPart = (LONGLONG)offset };
+			status = nt.NtReadFile( file, 0, 0, 0, &iostatus, buffer, bytes, &position, 0 );
+			return status >= 0 ? (uint32_t)iostatus.Information : 0;
+		}
+		static void close( HANDLE file ){
+			if( file && bind_ntdll() ){ nt.NtClose( file ); }
+		}
+		static uint32_t for_each_device( void(*found)( const wchar_t* device ) ){
+			if( ! bind_ntdll() ){ return 0; }
+			UNICODE_STRING devicedirectory = {
+				.Length			= sizeof(L"\\Device") - sizeof(wchar_t),
+				.MaximumLength	= sizeof(L"\\Device"),
+				.Buffer			= L"\\Device"
+			};
+			OBJECT_ATTRIBUTES attributes = {
+				.Length		= sizeof(attributes),
+				.ObjectName	= &devicedirectory,
+				.Attributes	= OBJ_CASE_INSENSITIVE
+			};
+			HANDLE directory = 0;
+			status = nt.NtOpenDirectoryObject( &directory, DIRECTORY_QUERY, &attributes );
+			if( status < 0 ){ return 0; }	/* querying \Device needs an elevated token */
+
+			uint32_t count = 0;
+			ULONG context = 0;
+			/*	one entry per call, the names live in the tail of the same buffer */
+			__declspec(align(8)) unsigned char entrybuffer[ 1024 ];
+			for(;;){
+				ULONG returned = 0;
+				status = nt.NtQueryDirectoryObject( directory, entrybuffer, sizeof(entrybuffer), TRUE, count == 0, &context, &returned );
+				if( status < 0 ){ break; }
+				const OBJECT_DIRECTORY_INFORMATION* const entry = (const OBJECT_DIRECTORY_INFORMATION*)entrybuffer;
+				if( entry->Name.Buffer == 0 ){ break; }
+				const wchar_t prefix[] = L"HarddiskVolumeShadowCopy";
+				const size_t prefixcharacters = ARRAYSIZE(prefix) - 1;
+				if( ( entry->Name.Length / sizeof(wchar_t) > prefixcharacters ) &&
+					( _wcsnicmp( entry->Name.Buffer, prefix, prefixcharacters ) == 0 ) ){
+					wchar_t device[ 256 ] = L"\\Device\\";
+					const size_t characters = entry->Name.Length / sizeof(wchar_t);
+					if( characters < ARRAYSIZE(device) - ARRAYSIZE(L"\\Device\\") ){
+						wmemcpy( device + wcslen(device), entry->Name.Buffer, characters );
+						count++;
+						if( found ){ found( device ); }
+					}
+				}
+				if( status == STATUS_NO_MORE_ENTRIES ){ break; }
+			}
+			nt.NtClose( directory );
+			return count;
+		}
+		static bool enable_backup_privilege( void ){
+			BOOLEAN wasenabled = FALSE;
+			if( ! bind_ntdll() ){ return false; }
+			status = nt.RtlAdjustPrivilege( SE_BACKUP_PRIVILEGE, TRUE, FALSE, &wasenabled );
+			return status >= 0;
+		}
+		static long last_status( void ){
+			return status;
+		}
+		typeof(shadowvolume) shadowvolume = {
+			.open						= open,
+			.read						= read,
+			.close						= close,
+			.for_each_device			= for_each_device,
+			.enable_backup_privilege	= enable_backup_privilege,
+			.last_status				= last_status
+		};
+
+		/*	clang -DSHADOWVOLUME_MAIN shadowvolume.c -o shadowvolume.exe, run elevated */
+#		ifdef SHADOWVOLUME_MAIN
+			static void print_device( const wchar_t* device ){
+				wprintf( L"found %s\n", device );
+			}
+			int main( int argc, char* argv[] ){
+				(void)argc; (void)argv;
+				shadowvolume.enable_backup_privilege();
+				if( shadowvolume.for_each_device( print_device ) == 0 ){
+					wprintf( L"no shadow copies present (status %08lX), create one first\n", shadowvolume.last_status() );
+					return 1;
+				}
+				/*	the event log is held open by the event log service, the snapshot is a
+					point in time copy of the volume, so this read never contends with it. */
+				const HANDLE file = shadowvolume.open(
+					L"\\Device\\HarddiskVolumeShadowCopy1",
+					L"\\Windows\\System32\\winevt\\Logs\\System.evtx"
+				);
+				if( file == 0 ){
+					wprintf( L"open failed with status %08lX\n", shadowvolume.last_status() );
+					return 1;
+				}
+				unsigned char header[ 8 ] = {};
+				const uint32_t bytes = shadowvolume.read( file, header, sizeof(header), 0 );
+				wprintf( L"read %u bytes: %hs\n", bytes, (char*)header );	/* "ElfFile" */
+				shadowvolume.close( file );
+				return 0;
+			}
+#		endif
+#	endif
+#endif

--- a/shadowvolume.c
+++ b/shadowvolume.c
@@ -5,8 +5,14 @@
 		\Device\HarddiskVolumeShadowCopyN - it has no drive letter and no dos device name,
 		so it is not reachable through the win32 namespace without the \\?\GLOBALROOT escape.
 		The nt api names objects directly, so we can just open the device relative path as it is. */
+	typedef struct mapping{
+		void*		base;		/* first byte of the mapped view */
+		uint32_t	size;		/* bytes mapped */
+		HANDLE		section;	/* the section object, kept so unmap can close it */
+	}mapping;
 	extern const struct shadowvolume{
-		/*	device is the shadow copy device, path is the file inside it:
+		/*	device is the shadow copy device, path is the file inside it - opened with
+			MAXIMUM_ALLOWED, so a read only snapshot hands back read, a writable volume everything:
 			shadowvolume.open( L"\\Device\\HarddiskVolumeShadowCopy1", L"\\Windows\\System32\\winevt\\Logs\\System.evtx" ) */
 		HANDLE(*open)( const wchar_t* device, const wchar_t* path );
 		uint32_t(*read)( HANDLE file, void* buffer, uint32_t bytes, uint64_t offset );
@@ -15,12 +21,29 @@
 		uint32_t(*for_each_device)( void(*found)( const wchar_t* device ) );
 		/*	reading other users files inside the snapshot needs SeBackupPrivilege enabled in the token */
 		bool(*enable_backup_privilege)( void );
+		/*	opens \??\C:\... for read+write, creating it or truncating an existing one.
+			a shadow copy is read only, so this is for a normal file, not a snapshot. */
+		HANDLE(*open_writable)( const wchar_t* ntpath );
+		/*	NtCreateSection + NtMapViewOfSection, read/write. size 0 maps the whole existing
+			file, otherwise that many bytes and the file is extended to fit. */
+		struct mapping(*map)( HANDLE file, uint32_t size );
+		/*	NtFlushVirtualMemory - pushes the dirty pages of the view back to the file */
+		bool(*flush)( struct mapping view );
+		/*	NtUnmapViewOfSection and closes the section object */
+		void(*unmap)( struct mapping view );
+		/*	searches <device>\Windows for filename (e.g. L"hh.exe") with NtQueryDirectoryFile,
+			and if it is there returns an open handle to it (MAXIMUM_ALLOWED) plus, in out_path,
+			its full nt path ready to hand to run(). returns 0 if it is not found. */
+		HANDLE(*find)( const wchar_t* device, const wchar_t* filename, wchar_t* out_path, size_t out_chars );
+		/*	RtlCreateUserProcess on an nt image path - creates the process from the image (the
+			one inside the snapshot), resumes its first thread and returns the process handle. */
+		HANDLE(*run)( const wchar_t* ntimagepath );
 		/*	the NTSTATUS of the last call, negative means failure */
 		long(*last_status)( void );
 	}shadowvolume;
 #	if __INCLUDE_LEVEL__ == 0
 		/*	the nt types are not in Windows.h - if you include <winternl.h> or the wdk headers
-			instead, drop this block, the guards below detect both of them. */
+			instead, drop this whole block, it also defines the process/section types below. */
 #		if !defined(_WINTERNL_) && !defined(_NTDEF_)
 			typedef struct _UNICODE_STRING{
 				USHORT Length;			/* in bytes, not characters, and without the terminator */
@@ -42,29 +65,56 @@
 				};
 				ULONG_PTR		Information;	/* bytes transferred for read/write */
 			}IO_STATUS_BLOCK, *PIO_STATUS_BLOCK;
+			typedef struct _CLIENT_ID{
+				HANDLE UniqueProcess;
+				HANDLE UniqueThread;
+			}CLIENT_ID;
+			typedef struct _RTL_USER_PROCESS_INFORMATION{
+				ULONG			Length;
+				HANDLE			ProcessHandle;
+				HANDLE			ThreadHandle;
+				CLIENT_ID		ClientId;
+				unsigned char	ImageInformation[ 128 ];	/* SECTION_IMAGE_INFORMATION, opaque here */
+			}RTL_USER_PROCESS_INFORMATION;
 #		endif
 		typedef struct _OBJECT_DIRECTORY_INFORMATION{
 			UNICODE_STRING Name;
 			UNICODE_STRING TypeName;
 		}OBJECT_DIRECTORY_INFORMATION;
 
-#		define OBJ_CASE_INSENSITIVE			0x00000040ul
-#		define FILE_OPEN					0x00000001ul	/* CreateDisposition: fail if it is not there */
-#		define FILE_SYNCHRONOUS_IO_NONALERT	0x00000020ul	/* the handle keeps its own file pointer, NtReadFile blocks */
-#		define FILE_NON_DIRECTORY_FILE		0x00000040ul
-#		define FILE_OPEN_FOR_BACKUP_INTENT	0x00004000ul	/* pairs with SeBackupPrivilege, like FILE_FLAG_BACKUP_SEMANTICS */
-#		define DIRECTORY_QUERY				0x00000001ul
-#		define STATUS_NO_MORE_ENTRIES		0x8000001Al
-#		define STATUS_INVALID_PARAMETER		0xC000000Dl
-#		define SE_BACKUP_PRIVILEGE			17ul
+#		define OBJ_CASE_INSENSITIVE				0x00000040ul
+#		define FILE_OPEN						0x00000001ul	/* CreateDisposition: fail if it is not there */
+#		define FILE_OVERWRITE_IF				0x00000005ul	/* CreateDisposition: create, or truncate an existing one */
+#		define FILE_DIRECTORY_FILE				0x00000001ul	/* CreateOptions: the target must be a directory */
+#		define FILE_SYNCHRONOUS_IO_NONALERT		0x00000020ul	/* the handle keeps its own file pointer, the nt call blocks */
+#		define FILE_NON_DIRECTORY_FILE			0x00000040ul
+#		define FILE_OPEN_FOR_BACKUP_INTENT		0x00004000ul	/* pairs with SeBackupPrivilege, like FILE_FLAG_BACKUP_SEMANTICS */
+#		define DIRECTORY_QUERY					0x00000001ul
+#		define FILE_DIRECTORY_INFORMATION_CLASS	1ul				/* FileInformationClass for NtQueryDirectoryFile */
+#		define STATUS_NO_MORE_ENTRIES			0x8000001Al
+#		define STATUS_INVALID_PARAMETER			0xC000000Dl
+#		define SE_BACKUP_PRIVILEGE				17ul
+#		define VIEW_UNMAP						2ul				/* SECTION_INHERIT: do not pass the view to children */
+#		define RTL_USER_PROC_PARAMS_NORMALIZED	0x00000001ul
+#		define NtCurrentProcess()				( (HANDLE)(LONG_PTR)-1 )
 
 		static struct{
 			NTSTATUS(NTAPI* NtOpenFile)( HANDLE*, ACCESS_MASK, OBJECT_ATTRIBUTES*, IO_STATUS_BLOCK*, ULONG share, ULONG options );
+			NTSTATUS(NTAPI* NtCreateFile)( HANDLE*, ACCESS_MASK, OBJECT_ATTRIBUTES*, IO_STATUS_BLOCK*, LARGE_INTEGER* alloc, ULONG attributes, ULONG share, ULONG disposition, ULONG options, PVOID ea, ULONG ealength );
 			NTSTATUS(NTAPI* NtReadFile)( HANDLE, HANDLE event, PVOID apc, PVOID apccontext, IO_STATUS_BLOCK*, PVOID buffer, ULONG length, LARGE_INTEGER* offset, ULONG* key );
 			NTSTATUS(NTAPI* NtClose)( HANDLE );
+			NTSTATUS(NTAPI* NtCreateSection)( HANDLE*, ACCESS_MASK, OBJECT_ATTRIBUTES*, LARGE_INTEGER* maximumsize, ULONG protect, ULONG attributes, HANDLE file );
+			NTSTATUS(NTAPI* NtMapViewOfSection)( HANDLE section, HANDLE process, PVOID* base, ULONG_PTR zerobits, SIZE_T commit, LARGE_INTEGER* offset, SIZE_T* viewsize, ULONG inherit, ULONG allocationtype, ULONG protect );
+			NTSTATUS(NTAPI* NtFlushVirtualMemory)( HANDLE process, PVOID* base, SIZE_T* size, IO_STATUS_BLOCK* );
+			NTSTATUS(NTAPI* NtUnmapViewOfSection)( HANDLE process, PVOID base );
 			NTSTATUS(NTAPI* NtOpenDirectoryObject)( HANDLE*, ACCESS_MASK, OBJECT_ATTRIBUTES* );
 			NTSTATUS(NTAPI* NtQueryDirectoryObject)( HANDLE, PVOID buffer, ULONG length, BOOLEAN singleentry, BOOLEAN restart, ULONG* context, ULONG* returnlength );
+			NTSTATUS(NTAPI* NtQueryDirectoryFile)( HANDLE, HANDLE event, PVOID apc, PVOID apccontext, IO_STATUS_BLOCK*, PVOID buffer, ULONG length, ULONG infoclass, BOOLEAN singleentry, UNICODE_STRING* mask, BOOLEAN restart );
+			NTSTATUS(NTAPI* NtResumeThread)( HANDLE, ULONG* previouscount );
 			NTSTATUS(NTAPI* RtlAdjustPrivilege)( ULONG privilege, BOOLEAN enable, BOOLEAN thisthreadonly, BOOLEAN* wasenabled );
+			NTSTATUS(NTAPI* RtlCreateProcessParametersEx)( PVOID* parameters, UNICODE_STRING* image, UNICODE_STRING* dllpath, UNICODE_STRING* currentdirectory, UNICODE_STRING* commandline, PVOID environment, UNICODE_STRING* windowtitle, UNICODE_STRING* desktop, UNICODE_STRING* shell, UNICODE_STRING* runtime, ULONG flags );
+			NTSTATUS(NTAPI* RtlCreateUserProcess)( UNICODE_STRING* image, ULONG attributes, PVOID parameters, PVOID processsd, PVOID threadsd, HANDLE parent, BOOLEAN inherithandles, HANDLE debugport, HANDLE token, RTL_USER_PROCESS_INFORMATION* information );
+			NTSTATUS(NTAPI* RtlDestroyProcessParameters)( PVOID parameters );
 		}nt;
 		static NTSTATUS status;
 
@@ -74,11 +124,21 @@
 			if( ntdll == 0 ){ return false; }
 #			define bind(function) ( nt.function = (typeof(nt.function))GetProcAddress( ntdll, #function ) )
 			return	bind(NtOpenFile) &&
+					bind(NtCreateFile) &&
 					bind(NtReadFile) &&
 					bind(NtClose) &&
+					bind(NtCreateSection) &&
+					bind(NtMapViewOfSection) &&
+					bind(NtFlushVirtualMemory) &&
+					bind(NtUnmapViewOfSection) &&
 					bind(NtOpenDirectoryObject) &&
 					bind(NtQueryDirectoryObject) &&
-					bind(RtlAdjustPrivilege);
+					bind(NtQueryDirectoryFile) &&
+					bind(NtResumeThread) &&
+					bind(RtlAdjustPrivilege) &&
+					bind(RtlCreateProcessParametersEx) &&
+					bind(RtlCreateUserProcess) &&
+					bind(RtlDestroyProcessParameters);
 #			undef bind
 		}
 		/*	joins \Device\HarddiskVolumeShadowCopyN and \some\file into one nt object path,
@@ -103,7 +163,9 @@
 			};
 			return true;
 		}
-		static HANDLE open( const wchar_t* device, const wchar_t* path ){
+		/*	opens an nt path with MAXIMUM_ALLOWED - the object manager hands back every right the
+			token is allowed on it, so a read only shadow copy gives read and a writable file gives all. */
+		static HANDLE open_nt( const wchar_t* device, const wchar_t* path, ULONG options ){
 			wchar_t pathbuffer[ 1024 ];
 			UNICODE_STRING objectname;
 			if( ! bind_ntdll() || ! nt_path( &objectname, pathbuffer, ARRAYSIZE(pathbuffer), device, path ) ){
@@ -115,17 +177,20 @@
 				.ObjectName	= &objectname,
 				.Attributes	= OBJ_CASE_INSENSITIVE
 			};
-			HANDLE file = 0;
+			HANDLE handle = 0;
 			IO_STATUS_BLOCK iostatus = {};
 			status = nt.NtOpenFile(
-				&file,
-				FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+				&handle,
+				MAXIMUM_ALLOWED | SYNCHRONIZE,
 				&attributes,
 				&iostatus,
 				FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-				FILE_SYNCHRONOUS_IO_NONALERT | FILE_NON_DIRECTORY_FILE | FILE_OPEN_FOR_BACKUP_INTENT
+				options
 			);
-			return status >= 0 ? file : 0;
+			return status >= 0 ? handle : 0;
+		}
+		static HANDLE open( const wchar_t* device, const wchar_t* path ){
+			return open_nt( device, path, FILE_SYNCHRONOUS_IO_NONALERT | FILE_NON_DIRECTORY_FILE | FILE_OPEN_FOR_BACKUP_INTENT );
 		}
 		static uint32_t read( HANDLE file, void* buffer, uint32_t bytes, uint64_t offset ){
 			if( ! bind_ntdll() ){ return 0; }
@@ -136,6 +201,150 @@
 		}
 		static void close( HANDLE file ){
 			if( file && bind_ntdll() ){ nt.NtClose( file ); }
+		}
+		static HANDLE open_writable( const wchar_t* ntpath ){
+			wchar_t pathbuffer[ 1024 ];
+			UNICODE_STRING objectname;
+			if( ! bind_ntdll() || ! nt_path( &objectname, pathbuffer, ARRAYSIZE(pathbuffer), ntpath, 0 ) ){
+				status = STATUS_INVALID_PARAMETER;
+				return 0;
+			}
+			OBJECT_ATTRIBUTES attributes = {
+				.Length		= sizeof(attributes),
+				.ObjectName	= &objectname,
+				.Attributes	= OBJ_CASE_INSENSITIVE
+			};
+			HANDLE file = 0;
+			IO_STATUS_BLOCK iostatus = {};
+			status = nt.NtCreateFile(
+				&file,
+				MAXIMUM_ALLOWED | SYNCHRONIZE,
+				&attributes,
+				&iostatus,
+				0,							/* the file grows to fit the section, no preallocation */
+				FILE_ATTRIBUTE_NORMAL,
+				FILE_SHARE_READ,
+				FILE_OVERWRITE_IF,			/* create it, or truncate one that is already there */
+				FILE_SYNCHRONOUS_IO_NONALERT | FILE_NON_DIRECTORY_FILE,
+				0, 0
+			);
+			return status >= 0 ? file : 0;
+		}
+		static struct mapping map( HANDLE file, uint32_t size ){
+			if( ( file == 0 ) || ! bind_ntdll() ){
+				status = STATUS_INVALID_PARAMETER;
+				return (struct mapping){};
+			}
+			HANDLE section = 0;
+			LARGE_INTEGER maximum = { .QuadPart = size };
+			/*	a writable file backed section, SEC_COMMIT so the pages are file backed.
+				passing a maximum larger than the file extends the file to that size. */
+			status = nt.NtCreateSection(
+				&section,
+				SECTION_MAP_READ | SECTION_MAP_WRITE,
+				0,
+				size ? &maximum : 0,
+				PAGE_READWRITE,
+				SEC_COMMIT,
+				file
+			);
+			if( status < 0 ){ return (struct mapping){}; }
+			PVOID base = 0;
+			SIZE_T viewsize = size;		/* 0 => the whole section */
+			status = nt.NtMapViewOfSection(
+				section, NtCurrentProcess(), &base, 0, 0, 0, &viewsize, VIEW_UNMAP, 0, PAGE_READWRITE
+			);
+			if( status < 0 ){
+				nt.NtClose( section );
+				return (struct mapping){};
+			}
+			return (struct mapping){ .base = base, .size = (uint32_t)viewsize, .section = section };
+		}
+		static bool flush( struct mapping view ){
+			if( ( view.base == 0 ) || ! bind_ntdll() ){ return false; }
+			PVOID base = view.base;
+			SIZE_T region = view.size;
+			IO_STATUS_BLOCK iostatus = {};
+			status = nt.NtFlushVirtualMemory( NtCurrentProcess(), &base, &region, &iostatus );
+			return status >= 0;
+		}
+		static void unmap( struct mapping view ){
+			if( ! bind_ntdll() ){ return; }
+			if( view.base ){ nt.NtUnmapViewOfSection( NtCurrentProcess(), view.base ); }
+			if( view.section ){ nt.NtClose( view.section ); }
+		}
+		static HANDLE find( const wchar_t* device, const wchar_t* filename, wchar_t* out_path, size_t out_chars ){
+			if( ! bind_ntdll() ){ status = STATUS_INVALID_PARAMETER; return 0; }
+			/*	open <device>\Windows as a directory to search it */
+			wchar_t buffer[ 1024 ];
+			UNICODE_STRING directoryname;
+			if( ! nt_path( &directoryname, buffer, ARRAYSIZE(buffer), device, L"\\Windows" ) ){
+				status = STATUS_INVALID_PARAMETER;
+				return 0;
+			}
+			OBJECT_ATTRIBUTES directoryattributes = {
+				.Length		= sizeof(directoryattributes),
+				.ObjectName	= &directoryname,
+				.Attributes	= OBJ_CASE_INSENSITIVE
+			};
+			HANDLE directory = 0;
+			IO_STATUS_BLOCK iostatus = {};
+			status = nt.NtOpenFile(
+				&directory,
+				FILE_LIST_DIRECTORY | SYNCHRONIZE,
+				&directoryattributes,
+				&iostatus,
+				FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+				FILE_SYNCHRONOUS_IO_NONALERT | FILE_DIRECTORY_FILE | FILE_OPEN_FOR_BACKUP_INTENT
+			);
+			if( status < 0 ){ return 0; }
+			/*	one entry, filtered by the filename mask - a hit means the file is there */
+			UNICODE_STRING mask = {
+				.Length			= (USHORT)( wcslen( filename ) * sizeof(wchar_t) ),
+				.MaximumLength	= (USHORT)( ( wcslen( filename ) + 1 ) * sizeof(wchar_t) ),
+				.Buffer			= (PWSTR)filename
+			};
+			__declspec(align(8)) unsigned char entry[ 1024 ];
+			status = nt.NtQueryDirectoryFile(
+				directory, 0, 0, 0, &iostatus, entry, sizeof(entry),
+				FILE_DIRECTORY_INFORMATION_CLASS, TRUE, &mask, TRUE
+			);
+			nt.NtClose( directory );
+			if( status < 0 ){ return 0; }	/* STATUS_NO_SUCH_FILE when it is not present */
+
+			/*	found it - open <device>\Windows\<filename> with maximum access */
+			wchar_t inside[ 1024 ] = L"\\Windows\\";
+			wmemcpy( inside + wcslen( inside ), filename, wcslen( filename ) + 1 );
+			const HANDLE file = open_nt( device, inside, FILE_SYNCHRONOUS_IO_NONALERT | FILE_NON_DIRECTORY_FILE | FILE_OPEN_FOR_BACKUP_INTENT );
+			if( ( file != 0 ) && out_path && out_chars ){
+				_snwprintf( out_path, out_chars, L"%ls\\Windows\\%ls", device, filename );
+				out_path[ out_chars - 1 ] = 0;
+			}
+			return file;
+		}
+		static HANDLE run( const wchar_t* ntimagepath ){
+			if( ! bind_ntdll() ){ status = STATUS_INVALID_PARAMETER; return 0; }
+			wchar_t buffer[ 1024 ];
+			UNICODE_STRING image;
+			if( ! nt_path( &image, buffer, ARRAYSIZE(buffer), ntimagepath, 0 ) ){
+				status = STATUS_INVALID_PARAMETER;
+				return 0;
+			}
+			PVOID parameters = 0;
+			status = nt.RtlCreateProcessParametersEx(
+				&parameters, &image, 0, 0, 0, 0, 0, 0, 0, 0, RTL_USER_PROC_PARAMS_NORMALIZED
+			);
+			if( status < 0 ){ return 0; }
+			/*	RtlCreateUserProcess sections the image itself and builds the process, suspended */
+			RTL_USER_PROCESS_INFORMATION information = { .Length = sizeof(information) };
+			status = nt.RtlCreateUserProcess(
+				&image, OBJ_CASE_INSENSITIVE, parameters, 0, 0, NtCurrentProcess(), FALSE, 0, 0, &information
+			);
+			nt.RtlDestroyProcessParameters( parameters );
+			if( status < 0 ){ return 0; }
+			nt.NtResumeThread( information.ThreadHandle, 0 );	/* let the first thread run */
+			nt.NtClose( information.ThreadHandle );
+			return information.ProcessHandle;
 		}
 		static uint32_t for_each_device( void(*found)( const wchar_t* device ) ){
 			if( ! bind_ntdll() ){ return 0; }
@@ -195,6 +404,12 @@
 			.close						= close,
 			.for_each_device			= for_each_device,
 			.enable_backup_privilege	= enable_backup_privilege,
+			.open_writable				= open_writable,
+			.map						= map,
+			.flush						= flush,
+			.unmap						= unmap,
+			.find						= find,
+			.run						= run,
 			.last_status				= last_status
 		};
 
@@ -208,22 +423,66 @@
 				shadowvolume.enable_backup_privilege();
 				if( shadowvolume.for_each_device( print_device ) == 0 ){
 					wprintf( L"no shadow copies present (status %08lX), create one first\n", shadowvolume.last_status() );
+				}else{
+					/*	the event log is held open by the event log service, the snapshot is a
+						point in time copy of the volume, so this read never contends with it. */
+					const HANDLE file = shadowvolume.open(
+						L"\\Device\\HarddiskVolumeShadowCopy1",
+						L"\\Windows\\System32\\winevt\\Logs\\System.evtx"
+					);
+					if( file == 0 ){
+						wprintf( L"open failed with status %08lX\n", shadowvolume.last_status() );
+					}else{
+						unsigned char header[ 8 ] = {};
+						const uint32_t bytes = shadowvolume.read( file, header, sizeof(header), 0 );
+						wprintf( L"read %u bytes from the snapshot: %hs\n", bytes, (char*)header );	/* "ElfFile" */
+						shadowvolume.close( file );
+					}
+				}
+
+				/*	Memory map a file with the nt api and change its bytes to %comspec%.
+					A shadow copy is read only, so the writable mapping targets a scratch
+					file under %TEMP% - \??\ is the nt symlink onto the win32 drive letters. */
+				wchar_t comspec[ MAX_PATH ] = {};
+				const DWORD comspecchars = ExpandEnvironmentStringsW( L"%comspec%", comspec, ARRAYSIZE(comspec) );	/* count includes the terminator */
+				wchar_t ntpath[ MAX_PATH ] = L"\\??\\";
+				ExpandEnvironmentStringsW( L"%TEMP%\\comspec.bin", ntpath + wcslen(ntpath), ARRAYSIZE(ntpath) - (DWORD)wcslen(ntpath) );
+
+				const HANDLE scratch = shadowvolume.open_writable( ntpath );
+				if( scratch != 0 ){
+					const uint32_t comspecbytes = comspecchars * sizeof(wchar_t);
+					const struct mapping view = shadowvolume.map( scratch, comspecbytes );	/* section extends the file to comspecbytes */
+					if( view.base != 0 ){
+						wmemcpy( (wchar_t*)view.base, comspec, comspecchars );	/* change the file's bytes to %comspec% */
+						shadowvolume.flush( view );								/* NtFlushVirtualMemory -> disk */
+						shadowvolume.unmap( view );								/* NtUnmapViewOfSection + close the section */
+						wprintf( L"wrote %u bytes of %%comspec%% (%ls) into %s\n", comspecbytes, comspec, ntpath );
+					}else{
+						wprintf( L"map failed with status %08lX\n", shadowvolume.last_status() );
+					}
+					shadowvolume.close( scratch );								/* NtClose the file */
+				}else{
+					wprintf( L"open_writable failed with status %08lX\n", shadowvolume.last_status() );
+				}
+
+				/*	Find hh.exe inside the snapshot, open it with maximum access, and run the
+					copy that lives in the shadow copy (not the live \Windows\hh.exe). */
+				wchar_t hhpath[ 1024 ] = {};
+				const HANDLE hh = shadowvolume.find( L"\\Device\\HarddiskVolumeShadowCopy1", L"hh.exe", hhpath, ARRAYSIZE(hhpath) );
+				if( hh == 0 ){
+					wprintf( L"hh.exe not found in the snapshot (status %08lX)\n", shadowvolume.last_status() );
 					return 1;
 				}
-				/*	the event log is held open by the event log service, the snapshot is a
-					point in time copy of the volume, so this read never contends with it. */
-				const HANDLE file = shadowvolume.open(
-					L"\\Device\\HarddiskVolumeShadowCopy1",
-					L"\\Windows\\System32\\winevt\\Logs\\System.evtx"
-				);
-				if( file == 0 ){
-					wprintf( L"open failed with status %08lX\n", shadowvolume.last_status() );
+				wprintf( L"found and opened %s\n", hhpath );
+				shadowvolume.close( hh );	/* the probe handle; run() sections the image by path */
+
+				const HANDLE process = shadowvolume.run( hhpath );
+				if( process == 0 ){
+					wprintf( L"run failed with status %08lX\n", shadowvolume.last_status() );
 					return 1;
 				}
-				unsigned char header[ 8 ] = {};
-				const uint32_t bytes = shadowvolume.read( file, header, sizeof(header), 0 );
-				wprintf( L"read %u bytes: %hs\n", bytes, (char*)header );	/* "ElfFile" */
-				shadowvolume.close( file );
+				wprintf( L"launched %s as process handle %p\n", hhpath, (void*)process );
+				shadowvolume.close( process );
 				return 0;
 			}
 #		endif

--- a/shadowvolume.ps1
+++ b/shadowvolume.ps1
@@ -1,0 +1,449 @@
+<#
+    shadowvolume.ps1 - the PowerShell companion to shadowvolume.c
+
+    Same idea as the C component: open, read, enumerate and map files that live
+    inside a Volume Shadow Copy (a VSS snapshot) named \Device\HarddiskVolumeShadowCopyN.
+    A snapshot has no drive letter, so CreateFileW / Get-Item cannot reach it as it is.
+
+    Two layers are shown here, matching the two honest answers to "can this be done
+    in PowerShell":
+
+      A. the easy way   - Win32_ShadowCopy for the device name + \\?\GLOBALROOT + .NET file IO.
+      B. the faithful way - Add-Type P/Invoke into the exact same ntdll exports the C file binds.
+
+    Dot-source it to get the $shadowvolume object without running the demo:
+        . .\shadowvolume.ps1
+    Run it directly (elevated) to run the demo:
+        .\shadowvolume.ps1
+#>
+
+Set-StrictMode -Version Latest
+
+# ---------------------------------------------------------------------------
+#  B. The native surface, declared once.
+#
+#  [DllImport("ntdll.dll")] is the PowerShell equivalent of the C file's
+#  GetModuleHandleW("ntdll.dll") + GetProcAddress binding - the CLR resolves the
+#  exports itself, so there is no bind_ntdll() scaffolding to write.
+# ---------------------------------------------------------------------------
+if( -not ( 'Nt.Native' -as [type] ) ){
+Add-Type -Namespace Nt -Name Native -PassThru -MemberDefinition @'
+    // the nt types are not in a normal reference assembly, so declare them,
+    // same as the C file declares them when you do not include <winternl.h>.
+    [StructLayout(LayoutKind.Sequential)]
+    public struct UNICODE_STRING {
+        public ushort Length;           // in bytes, without the terminator
+        public ushort MaximumLength;    // in bytes, room for the terminator
+        public IntPtr Buffer;           // a pinned wchar_t*
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    public struct OBJECT_ATTRIBUTES {
+        public int    Length;
+        public IntPtr RootDirectory;
+        public IntPtr ObjectName;       // UNICODE_STRING*
+        public uint   Attributes;
+        public IntPtr SecurityDescriptor;
+        public IntPtr SecurityQualityOfService;
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    public struct IO_STATUS_BLOCK {
+        public IntPtr Status;
+        public IntPtr Information;       // bytes transferred for read/write
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    public struct OBJECT_DIRECTORY_INFORMATION {
+        public UNICODE_STRING Name;
+        public UNICODE_STRING TypeName;
+    }
+
+    [DllImport("ntdll.dll")] public static extern int NtOpenFile(
+        out IntPtr handle, uint access, ref OBJECT_ATTRIBUTES attributes,
+        out IO_STATUS_BLOCK iostatus, uint share, uint options );
+
+    [DllImport("ntdll.dll")] public static extern int NtCreateFile(
+        out IntPtr handle, uint access, ref OBJECT_ATTRIBUTES attributes,
+        out IO_STATUS_BLOCK iostatus, IntPtr allocationsize, uint fileattributes,
+        uint share, uint disposition, uint options, IntPtr ea, uint ealength );
+
+    [DllImport("ntdll.dll")] public static extern int NtReadFile(
+        IntPtr handle, IntPtr evt, IntPtr apc, IntPtr apccontext,
+        out IO_STATUS_BLOCK iostatus, byte[] buffer, uint length,
+        ref long offset, IntPtr key );
+
+    [DllImport("ntdll.dll")] public static extern int NtClose( IntPtr handle );
+
+    [DllImport("ntdll.dll")] public static extern int NtCreateSection(
+        out IntPtr section, uint access, IntPtr attributes, ref long maximumsize,
+        uint protect, uint allocationattributes, IntPtr file );
+
+    [DllImport("ntdll.dll")] public static extern int NtMapViewOfSection(
+        IntPtr section, IntPtr process, ref IntPtr baseaddress, IntPtr zerobits,
+        IntPtr commitsize, IntPtr sectionoffset, ref IntPtr viewsize,
+        uint inherit, uint allocationtype, uint protect );
+
+    [DllImport("ntdll.dll")] public static extern int NtFlushVirtualMemory(
+        IntPtr process, ref IntPtr baseaddress, ref IntPtr size, out IO_STATUS_BLOCK iostatus );
+
+    [DllImport("ntdll.dll")] public static extern int NtUnmapViewOfSection(
+        IntPtr process, IntPtr baseaddress );
+
+    [DllImport("ntdll.dll")] public static extern int NtOpenDirectoryObject(
+        out IntPtr handle, uint access, ref OBJECT_ATTRIBUTES attributes );
+
+    [DllImport("ntdll.dll")] public static extern int NtQueryDirectoryObject(
+        IntPtr handle, IntPtr buffer, uint length, byte singleentry, byte restart,
+        ref uint context, out uint returnlength );
+
+    [DllImport("ntdll.dll")] public static extern int NtQueryDirectoryFile(
+        IntPtr handle, IntPtr evt, IntPtr apc, IntPtr apccontext,
+        out IO_STATUS_BLOCK iostatus, IntPtr buffer, uint length, uint infoclass,
+        byte singleentry, ref UNICODE_STRING mask, byte restart );
+
+    [DllImport("ntdll.dll")] public static extern int RtlAdjustPrivilege(
+        uint privilege, byte enable, byte thisthreadonly, out byte wasenabled );
+'@ | Out-Null
+}
+
+# NT flags / constants - the same values shadowvolume.c defines.
+$NT = @{
+    OBJ_CASE_INSENSITIVE           = 0x00000040
+    MAXIMUM_ALLOWED                = 0x02000000
+    SYNCHRONIZE                    = 0x00100000
+    FILE_LIST_DIRECTORY            = 0x00000001
+    FILE_SHARE_READ                = 0x00000001
+    FILE_SHARE_WRITE               = 0x00000002
+    FILE_SHARE_DELETE              = 0x00000004
+    FILE_ATTRIBUTE_NORMAL          = 0x00000080
+    FILE_OVERWRITE_IF              = 0x00000005
+    FILE_DIRECTORY_FILE            = 0x00000001
+    FILE_SYNCHRONOUS_IO_NONALERT   = 0x00000020
+    FILE_NON_DIRECTORY_FILE        = 0x00000040
+    FILE_OPEN_FOR_BACKUP_INTENT    = 0x00004000
+    DIRECTORY_QUERY                = 0x00000001
+    FILE_DIRECTORY_INFORMATION     = 1
+    SEC_COMMIT                     = 0x08000000
+    PAGE_READWRITE                 = 0x00000004
+    SECTION_MAP_READ               = 0x00000004
+    SECTION_MAP_WRITE              = 0x00000002
+    VIEW_UNMAP                     = 2
+    SE_BACKUP_PRIVILEGE            = 17
+    # NTSTATUS values are unsigned; store them as the signed int32 the DllImports return
+    # (a plain [int]0x8000001A would overflow, the hex parses as a long that will not cast).
+    STATUS_NO_MORE_ENTRIES         = [System.BitConverter]::ToInt32( [System.BitConverter]::GetBytes( [uint32] 0x8000001A ), 0 )
+    STATUS_INVALID_PARAMETER       = [System.BitConverter]::ToInt32( [System.BitConverter]::GetBytes( [uint32] 0xC000000D ), 0 )
+}
+$NtCurrentProcess = [IntPtr]-1
+
+# ---------------------------------------------------------------------------
+#  The interface.
+#
+#  The C file is a struct of function pointers filled in at the bottom of the
+#  file; the natural PowerShell parallel is a [pscustomobject] whose members are
+#  ScriptMethods, assembled here in one place. Same shape, same verbs.
+# ---------------------------------------------------------------------------
+$script:LastStatus = 0
+
+# build "\Device\HarddiskVolumeShadowCopyN" + "\some\file" into a pinned UNICODE_STRING.
+# UNICODE_STRING carries a byte Length, so it never depends on a terminator - but we keep
+# the buffer zero terminated so it stays printable, exactly like nt_path() in the C file.
+function New-NtPath {
+    param( [string] $Device, [string] $Path )
+    $device = if( $Device ){ $Device } else { '' }
+    $path   = if( $Path )   { $Path }   else { '' }
+    $separator = ( $path.Length -ne 0 ) -and ( $path[0] -ne '\' ) -and ( $device[ $device.Length - 1 ] -ne '\' )
+    $joined = $device + $( if( $separator ){ '\' } else { '' } ) + $path
+    if( ( $device.Length -eq 0 ) -or ( $joined.Length * 2 -gt 0xFFFE ) ){ return $null }
+    $buffer = [System.Runtime.InteropServices.Marshal]::StringToHGlobalUni( $joined )   # wchar_t*, zero terminated
+    $us = New-Object Nt.Native+UNICODE_STRING
+    $us.Length        = [ushort]( $joined.Length * 2 )
+    $us.MaximumLength = [ushort]( ( $joined.Length + 1 ) * 2 )
+    $us.Buffer        = $buffer
+    # pin the UNICODE_STRING itself so we can pass its address as ObjectName
+    $us_native = [System.Runtime.InteropServices.Marshal]::AllocHGlobal( [System.Runtime.InteropServices.Marshal]::SizeOf( $us ) )
+    [System.Runtime.InteropServices.Marshal]::StructureToPtr( $us, $us_native, $false )
+    [pscustomobject]@{ Struct = $us; Native = $us_native; Buffer = $buffer }
+}
+function Free-NtPath {
+    param( $NtPath )
+    if( $NtPath.Native ){ [System.Runtime.InteropServices.Marshal]::FreeHGlobal( $NtPath.Native ) }
+    if( $NtPath.Buffer ){ [System.Runtime.InteropServices.Marshal]::FreeHGlobal( $NtPath.Buffer ) }
+}
+
+function New-ObjectAttributes {
+    param( [IntPtr] $ObjectName )
+    $oa = New-Object Nt.Native+OBJECT_ATTRIBUTES
+    $oa.Length     = [System.Runtime.InteropServices.Marshal]::SizeOf( $oa )
+    $oa.ObjectName = $ObjectName
+    $oa.Attributes = $NT.OBJ_CASE_INSENSITIVE
+    $oa
+}
+
+# open an nt path with MAXIMUM_ALLOWED, the object manager hands back every right the
+# token is allowed on it - read on a read-only snapshot, everything on a writable volume.
+function Invoke-NtOpen {
+    param( [string] $Device, [string] $Path, [uint32] $Options )
+    $ntpath = New-NtPath -Device $Device -Path $Path
+    if( $null -eq $ntpath ){ $script:LastStatus = $NT.STATUS_INVALID_PARAMETER; return [IntPtr]::Zero }
+    try {
+        $oa = New-ObjectAttributes -ObjectName $ntpath.Native
+        $iostatus = New-Object Nt.Native+IO_STATUS_BLOCK
+        $handle = [IntPtr]::Zero
+        $script:LastStatus = [Nt.Native]::NtOpenFile(
+            [ref] $handle,
+            [uint32]( $NT.MAXIMUM_ALLOWED -bor $NT.SYNCHRONIZE ),
+            [ref] $oa, [ref] $iostatus,
+            [uint32]( $NT.FILE_SHARE_READ -bor $NT.FILE_SHARE_WRITE -bor $NT.FILE_SHARE_DELETE ),
+            $Options )
+        if( $script:LastStatus -ge 0 ){ $handle } else { [IntPtr]::Zero }
+    } finally { Free-NtPath $ntpath }
+}
+
+$shadowvolume = [pscustomobject]@{}
+
+# open( device, path ) - the file inside the snapshot, opened for backup intent.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name Open -Value {
+    param( [string] $Device, [string] $Path )
+    Invoke-NtOpen -Device $Device -Path $Path -Options ( $NT.FILE_SYNCHRONOUS_IO_NONALERT -bor $NT.FILE_NON_DIRECTORY_FILE -bor $NT.FILE_OPEN_FOR_BACKUP_INTENT )
+}
+
+# read( file, bytes, offset ) - NtReadFile with an explicit offset, no file-pointer dependency.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name Read -Value {
+    param( [IntPtr] $File, [int] $Bytes, [long] $Offset )
+    $buffer = New-Object byte[] $Bytes
+    $iostatus = New-Object Nt.Native+IO_STATUS_BLOCK
+    $position = $Offset
+    $script:LastStatus = [Nt.Native]::NtReadFile( $File, [IntPtr]::Zero, [IntPtr]::Zero, [IntPtr]::Zero, [ref] $iostatus, $buffer, [uint32] $Bytes, [ref] $position, [IntPtr]::Zero )
+    if( $script:LastStatus -ge 0 ){
+        $read = [int] $iostatus.Information
+        if( $read -lt $Bytes ){ $buffer[0..($read-1)] } else { $buffer }
+    } else { $null }
+}
+
+# close( file )
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name Close -Value {
+    param( [IntPtr] $File )
+    if( $File -ne [IntPtr]::Zero ){ [void] [Nt.Native]::NtClose( $File ) }
+}
+
+# for_each_device() - walk \Device, return every HarddiskVolumeShadowCopyN present.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name ForEachDevice -Value {
+    $ntpath = New-NtPath -Device '\Device' -Path ''
+    $devices = New-Object System.Collections.Generic.List[string]
+    try {
+        $oa = New-ObjectAttributes -ObjectName $ntpath.Native
+        $directory = [IntPtr]::Zero
+        $script:LastStatus = [Nt.Native]::NtOpenDirectoryObject( [ref] $directory, [uint32] $NT.DIRECTORY_QUERY, [ref] $oa )
+        if( $script:LastStatus -lt 0 ){ return $devices }   # querying \Device needs an elevated token
+        $size = 2048
+        $buffer = [System.Runtime.InteropServices.Marshal]::AllocHGlobal( $size )
+        try {
+            $context = [uint32] 0
+            $first = $true
+            while( $true ){
+                $returned = [uint32] 0
+                $script:LastStatus = [Nt.Native]::NtQueryDirectoryObject( $directory, $buffer, [uint32] $size, 1, $( if( $first ){ 1 } else { 0 } ), [ref] $context, [ref] $returned )
+                if( $script:LastStatus -lt 0 ){ break }
+                $first = $false
+                $entry = [System.Runtime.InteropServices.Marshal]::PtrToStructure( $buffer, [type] 'Nt.Native+OBJECT_DIRECTORY_INFORMATION' )
+                if( $entry.Name.Buffer -eq [IntPtr]::Zero ){ break }
+                $name = [System.Runtime.InteropServices.Marshal]::PtrToStringUni( $entry.Name.Buffer, $entry.Name.Length / 2 )
+                if( $name -like 'HarddiskVolumeShadowCopy*' ){ $devices.Add( "\Device\$name" ) }
+                if( $script:LastStatus -eq $NT.STATUS_NO_MORE_ENTRIES ){ break }
+            }
+        } finally { [System.Runtime.InteropServices.Marshal]::FreeHGlobal( $buffer ) }
+        [void] [Nt.Native]::NtClose( $directory )
+    } finally { Free-NtPath $ntpath }
+    $devices
+}
+
+# enable_backup_privilege() - SeBackupPrivilege lets a backup operator read files the ACL denies.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name EnableBackupPrivilege -Value {
+    $wasenabled = [byte] 0
+    $script:LastStatus = [Nt.Native]::RtlAdjustPrivilege( [uint32] $NT.SE_BACKUP_PRIVILEGE, 1, 0, [ref] $wasenabled )
+    $script:LastStatus -ge 0
+}
+
+# open_writable( ntpath ) - NtCreateFile, \??\C:\... create-or-truncate. A snapshot is read only,
+# so this is for a normal file, the target the writable mapping needs.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name OpenWritable -Value {
+    param( [string] $NtPath )
+    $ntpath = New-NtPath -Device $NtPath -Path ''
+    if( $null -eq $ntpath ){ $script:LastStatus = $NT.STATUS_INVALID_PARAMETER; return [IntPtr]::Zero }
+    try {
+        $oa = New-ObjectAttributes -ObjectName $ntpath.Native
+        $iostatus = New-Object Nt.Native+IO_STATUS_BLOCK
+        $file = [IntPtr]::Zero
+        $script:LastStatus = [Nt.Native]::NtCreateFile(
+            [ref] $file,
+            [uint32]( $NT.MAXIMUM_ALLOWED -bor $NT.SYNCHRONIZE ),
+            [ref] $oa, [ref] $iostatus,
+            [IntPtr]::Zero,                     # the file grows to fit the section, no preallocation
+            [uint32] $NT.FILE_ATTRIBUTE_NORMAL,
+            [uint32] $NT.FILE_SHARE_READ,
+            [uint32] $NT.FILE_OVERWRITE_IF,     # create it, or truncate one already there
+            [uint32]( $NT.FILE_SYNCHRONOUS_IO_NONALERT -bor $NT.FILE_NON_DIRECTORY_FILE ),
+            [IntPtr]::Zero, 0 )
+        if( $script:LastStatus -ge 0 ){ $file } else { [IntPtr]::Zero }
+    } finally { Free-NtPath $ntpath }
+}
+
+# map( file, size ) - NtCreateSection + NtMapViewOfSection, read/write. size 0 maps the whole
+# existing file, otherwise that many bytes and the file is extended to fit.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name Map -Value {
+    param( [IntPtr] $File, [int] $Size )
+    if( $File -eq [IntPtr]::Zero ){ $script:LastStatus = $NT.STATUS_INVALID_PARAMETER; return $null }
+    $section = [IntPtr]::Zero
+    $maximum = [long] $Size
+    $script:LastStatus = [Nt.Native]::NtCreateSection(
+        [ref] $section,
+        [uint32]( $NT.SECTION_MAP_READ -bor $NT.SECTION_MAP_WRITE ),
+        [IntPtr]::Zero, [ref] $maximum,
+        [uint32] $NT.PAGE_READWRITE, [uint32] $NT.SEC_COMMIT, $File )
+    if( $script:LastStatus -lt 0 ){ return $null }
+    $base = [IntPtr]::Zero
+    $viewsize = [IntPtr] $Size          # 0 => the whole section
+    $script:LastStatus = [Nt.Native]::NtMapViewOfSection(
+        $section, $NtCurrentProcess, [ref] $base, [IntPtr]::Zero, [IntPtr]::Zero, [IntPtr]::Zero,
+        [ref] $viewsize, [uint32] $NT.VIEW_UNMAP, 0, [uint32] $NT.PAGE_READWRITE )
+    if( $script:LastStatus -lt 0 ){ [void] [Nt.Native]::NtClose( $section ); return $null }
+    [pscustomobject]@{ Base = $base; Size = [int] $viewsize; Section = $section }
+}
+
+# write bytes into a mapped view - PowerShell reaches the view through Marshal.Copy,
+# there is no raw pointer arithmetic like the C wmemcpy into view.base.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name WriteView -Value {
+    param( $View, [byte[]] $Bytes )
+    [System.Runtime.InteropServices.Marshal]::Copy( $Bytes, 0, $View.Base, [Math]::Min( $Bytes.Length, $View.Size ) )
+}
+
+# flush( view ) - NtFlushVirtualMemory pushes the dirty pages back to the file.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name Flush -Value {
+    param( $View )
+    if( $null -eq $View ){ return $false }
+    $base = $View.Base
+    $region = [IntPtr] $View.Size
+    $iostatus = New-Object Nt.Native+IO_STATUS_BLOCK
+    $script:LastStatus = [Nt.Native]::NtFlushVirtualMemory( $NtCurrentProcess, [ref] $base, [ref] $region, [ref] $iostatus )
+    $script:LastStatus -ge 0
+}
+
+# unmap( view ) - NtUnmapViewOfSection and close the section.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name Unmap -Value {
+    param( $View )
+    if( $null -eq $View ){ return }
+    if( $View.Base    -ne [IntPtr]::Zero ){ [void] [Nt.Native]::NtUnmapViewOfSection( $NtCurrentProcess, $View.Base ) }
+    if( $View.Section -ne [IntPtr]::Zero ){ [void] [Nt.Native]::NtClose( $View.Section ) }
+}
+
+# find( device, filename ) - NtQueryDirectoryFile a single-entry mask in <device>\Windows;
+# a hit returns the full nt path, ready to hand to run(). $null if it is not there.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name Find -Value {
+    param( [string] $Device, [string] $Filename )
+    $dir = New-NtPath -Device $Device -Path '\Windows'
+    if( $null -eq $dir ){ $script:LastStatus = $NT.STATUS_INVALID_PARAMETER; return $null }
+    $maskpath = $null
+    try {
+        $oa = New-ObjectAttributes -ObjectName $dir.Native
+        $iostatus = New-Object Nt.Native+IO_STATUS_BLOCK
+        $directory = [IntPtr]::Zero
+        $script:LastStatus = [Nt.Native]::NtOpenFile(
+            [ref] $directory,
+            [uint32]( $NT.FILE_LIST_DIRECTORY -bor $NT.SYNCHRONIZE ),
+            [ref] $oa, [ref] $iostatus,
+            [uint32]( $NT.FILE_SHARE_READ -bor $NT.FILE_SHARE_WRITE -bor $NT.FILE_SHARE_DELETE ),
+            [uint32]( $NT.FILE_SYNCHRONOUS_IO_NONALERT -bor $NT.FILE_DIRECTORY_FILE -bor $NT.FILE_OPEN_FOR_BACKUP_INTENT ) )
+        if( $script:LastStatus -lt 0 ){ return $null }
+        $maskbuffer = [System.Runtime.InteropServices.Marshal]::StringToHGlobalUni( $Filename )
+        $mask = New-Object Nt.Native+UNICODE_STRING
+        $mask.Length        = [ushort]( $Filename.Length * 2 )
+        $mask.MaximumLength = [ushort]( ( $Filename.Length + 1 ) * 2 )
+        $mask.Buffer        = $maskbuffer
+        $entry = [System.Runtime.InteropServices.Marshal]::AllocHGlobal( 2048 )
+        try {
+            $script:LastStatus = [Nt.Native]::NtQueryDirectoryFile(
+                $directory, [IntPtr]::Zero, [IntPtr]::Zero, [IntPtr]::Zero, [ref] $iostatus,
+                $entry, 2048, [uint32] $NT.FILE_DIRECTORY_INFORMATION, 1, [ref] $mask, 1 )
+        } finally {
+            [System.Runtime.InteropServices.Marshal]::FreeHGlobal( $entry )
+            [System.Runtime.InteropServices.Marshal]::FreeHGlobal( $maskbuffer )
+        }
+        [void] [Nt.Native]::NtClose( $directory )
+        if( $script:LastStatus -lt 0 ){ return $null }   # STATUS_NO_SUCH_FILE when it is not present
+        "$Device\Windows\$Filename"
+    } finally { Free-NtPath $dir }
+}
+
+# last_status() - the NTSTATUS of the last call, negative means failure.
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name LastStatus -Value { $script:LastStatus }
+
+# ---------------------------------------------------------------------------
+#  A. The easy way, for contrast: no P/Invoke at all.
+#  Win32_ShadowCopy gives the device object, \\?\GLOBALROOT lets .NET reach it -
+#  this is the \\?\GLOBALROOT escape the C article deliberately avoids.
+# ---------------------------------------------------------------------------
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name ListShadowCopiesWmi -Value {
+    Get-CimInstance -ClassName Win32_ShadowCopy | Select-Object -ExpandProperty DeviceObject
+}
+$shadowvolume | Add-Member -MemberType ScriptMethod -Name ReadViaGlobalRoot -Value {
+    param( [string] $DeviceObject, [string] $RelativePath )
+    # $DeviceObject is \\?\GLOBALROOT\Device\HarddiskVolumeShadowCopyN
+    [System.IO.File]::ReadAllBytes( ( Join-Path $DeviceObject $RelativePath ) )
+}
+
+# ---------------------------------------------------------------------------
+#  The demo - the PowerShell analog of the C file's __INCLUDE_LEVEL__ == 0 /
+#  -DSHADOWVOLUME_MAIN block. It runs only when the script is invoked directly,
+#  not when it is dot-sourced (InvocationName is '.' for a dot-source).
+# ---------------------------------------------------------------------------
+if( $MyInvocation.InvocationName -ne '.' ){
+    [void] $shadowvolume.EnableBackupPrivilege()
+
+    $devices = $shadowvolume.ForEachDevice()
+    if( $devices.Count -eq 0 ){
+        Write-Host ( "no shadow copies present (status {0:X8}), create one first" -f $shadowvolume.LastStatus() )
+    } else {
+        $devices | ForEach-Object { Write-Host "found $_" }
+
+        # the event log is held open by the event log service; the snapshot is a point in
+        # time copy, so this read never contends with it.
+        $file = $shadowvolume.Open( '\Device\HarddiskVolumeShadowCopy1', '\Windows\System32\winevt\Logs\System.evtx' )
+        if( $file -eq [IntPtr]::Zero ){
+            Write-Host ( "open failed with status {0:X8}" -f $shadowvolume.LastStatus() )
+        } else {
+            $header = $shadowvolume.Read( $file, 8, 0 )
+            if( $header ){ Write-Host ( "read {0} bytes from the snapshot: {1}" -f $header.Length, [System.Text.Encoding]::ASCII.GetString( $header ) ) }  # "ElfFile"
+            $shadowvolume.Close( $file )
+        }
+    }
+
+    # Memory map a scratch file under %TEMP% and change its bytes to %comspec%.
+    # \??\ is the nt symlink onto the win32 drive letters.
+    $comspec  = [System.Environment]::ExpandEnvironmentVariables( '%comspec%' )
+    $ntpath   = '\??\' + [System.Environment]::ExpandEnvironmentVariables( '%TEMP%\comspec.bin' )
+    $bytes    = [System.Text.Encoding]::Unicode.GetBytes( $comspec + "`0" )
+
+    $scratch = $shadowvolume.OpenWritable( $ntpath )
+    if( $scratch -ne [IntPtr]::Zero ){
+        $view = $shadowvolume.Map( $scratch, $bytes.Length )     # the section extends the file to fit
+        if( $view ){
+            $shadowvolume.WriteView( $view, $bytes )
+            [void] $shadowvolume.Flush( $view )
+            $shadowvolume.Unmap( $view )
+            Write-Host ( "wrote {0} bytes of %comspec% ({1}) into {2}" -f $bytes.Length, $comspec, $ntpath )
+        } else {
+            Write-Host ( "map failed with status {0:X8}" -f $shadowvolume.LastStatus() )
+        }
+        $shadowvolume.Close( $scratch )
+    } else {
+        Write-Host ( "open_writable failed with status {0:X8}" -f $shadowvolume.LastStatus() )
+    }
+
+    # Find hh.exe inside the snapshot and open it with maximum access. The article shows
+    # how run() would section and launch that copy with RtlCreateUserProcess.
+    $hhpath = $shadowvolume.Find( '\Device\HarddiskVolumeShadowCopy1', 'hh.exe' )
+    if( $hhpath ){
+        Write-Host "found $hhpath in the snapshot"
+    } else {
+        Write-Host ( "hh.exe not found in the snapshot (status {0:X8})" -f $shadowvolume.LastStatus() )
+    }
+}


### PR DESCRIPTION
## Summary
Add a new `shadowvolume` component that provides a high-level interface for opening, reading, and manipulating files within Volume Shadow Copy (VSS) snapshots using the native NT API instead of Win32 layer abstractions.

## Key Changes
- **New shadowvolume.c component**: Implements direct NT API access to shadow copy volumes with the following capabilities:
  - Open files within shadow copies (`\Device\HarddiskVolumeShadowCopyN`)
  - Read file contents with explicit byte offsets
  - Enumerate available shadow copy devices
  - Enable `SeBackupPrivilege` for accessing other users' files in snapshots
  - Memory-map files for read/write access with flush support
  - Find and execute binaries from within snapshots
  - Runtime binding of ntdll functions via `GetProcAddress`

- **Self-contained NT API definitions**: Includes necessary NT structures (`UNICODE_STRING`, `OBJECT_ATTRIBUTES`, `IO_STATUS_BLOCK`, etc.) with guards to avoid conflicts with `<winternl.h>` or WDK headers

- **Comprehensive documentation**: Added `06-shadowvolume.c.md` explaining:
  - Why the NT API is necessary (shadow copies lack drive letters/DOS names)
  - Interface design and usage patterns
  - Runtime function binding approach
  - Memory mapping and file manipulation examples
  - Process creation from snapshot binaries

- **Working example**: Included `SHADOWVOLUME_MAIN` demo that:
  - Lists available shadow copy devices
  - Reads the System event log from a snapshot
  - Memory-maps and modifies a scratch file
  - Locates and executes `hh.exe` from within a snapshot

- **Project integration**: Updated `coope.vcxproj` to include the new component in the build

## Notable Implementation Details
- Uses `UNICODE_STRING` with explicit byte lengths to avoid terminator dependencies
- Implements path joining with automatic separator handling
- Leverages `MAXIMUM_ALLOWED` access mask to grant maximum available permissions
- Supports both read-only snapshots and writable file mappings
- Provides synchronous I/O with explicit file pointers for straightforward control flow

https://claude.ai/code/session_011LuMn9NEz9aHjDL6AevpFz