### PR TITLE
Add comprehensive documentation for drawable, timer, string, console, and test components

### DIFF
--- a/06-drawables.c.md
+++ b/06-drawables.c.md
@@ -1,0 +1,126 @@
+### drawable.c and drawables.c
+
+These two files belong together: `drawable.c` is the interface a component implements when it wants to be drawn, and `drawables.c` is the collection that keeps track of every such object and paints them into the console buffer.
+
+Notice that `drawable.c` has no private part at all- there is no `__INCLUDE_LEVEL__` block in it. There is nothing to implement, the file is pure interface, so the whole file is the public part.
+
+```c
+#include "stdafx.h"
+#ifndef drawable
+#	define drawable drawable
+	typedef union{
+		struct drawable{
+			struct drawable* object;
+			union{
+				struct drawable_vtable{
+					void (*draw)( struct drawable* this, struct _CHAR_INFO* const consoleBuffer, int16_t rownr );
+				}drawable_vtable;
+				struct drawable_vtable;
+			};
+		}drawable;
+		struct drawable;
+	}drawable;
+#endif
+```
+
+This is the same union, named struct, unnamed struct pattern from the box- the members are reachable both as `drawable.drawable_vtable.draw` and directly as `drawable.draw`, and because it is a union they are the very same bytes.
+
+The interface is two things only:
+- `object`- the pointer that gets passed back as the first argument when we call draw. This is the compensation for c not having a thiscall calling convention, exactly like the `this` function does it for the array.
+- `draw`- draw *one row* of yourself into the buffer you are handed.
+
+That is the whole contract. A drawable never learns where it is on the screen, and it never learns how big the console is. It is told: here is a pointer into the buffer where your row starts, and this is which of your own rows it is. Everything else is the collection's problem.
+
+`box.c` implements this by simply writing `drawable;` as the first member of its public `struct box_interface`- so a `struct box*` starts with a `struct drawable`, and that is what makes the transparent union trick in `box.new` legal.
+
+### drawables.c
+
+The public part first:
+
+```c
+	typedef	struct drawable_in_grid{
+		union{
+			struct grid_position{
+				int16_t x;
+				int16_t y;
+			}grid_position;
+			struct grid_position;
+		};
+		drawable;
+	}drawable_in_grid;
+	extern struct{
+		void (*draw_all)( CHAR_INFO* const consolebuffer, int16_t width, int16_t height );
+		void (*add)( struct grid_position grid_position, const struct drawable* const toadd );
+	}drawable_objects;
+```
+
+A `drawable_in_grid` is just a drawable that has been given a place to live. Because both the position and the drawable are flattened in, one element gives us `element.x`, `element.y`, `element.object` and `element.draw` all directly- while `grid_position` is still a nameable type on its own, which is what lets `console.add_box` and `main.c` pass a position around as a value.
+
+`grid_position` being declared here rather than in the box is deliberate- position is not a property of a box, it is a property of a box *in this collection*. A box has a size, not a location.
+
+Then the usual extern struct that the private part fills in at compile time.
+
+### The include cycle
+
+```c
+#	if __INCLUDE_LEVEL__ == 0
+#		include "array.c"
+		static struct array_of_drawable_in_grid drawables;
+```
+
+Worth stopping at. `array.c` includes `drawables.c` at the top of *its* public part- because `drawable_in_grid` is one of the entries in the `TYPES` list, so the array component needs the type to generate `struct array_of_drawable_in_grid` for it. And here `drawables.c` includes `array.c` right back.
+
+That would be a loop, except the `#ifndef` guard on each file makes the second visit expand to nothing. And notice the direction: `drawables.c` only reaches for `array.c` from *inside* its private part. The public interface of drawables does not depend on arrays at all- the array is an implementation detail of the collection, so it stays behind the `__INCLUDE_LEVEL__` fence and nobody who includes `drawables.c` pays for it.
+
+The collection itself is one static, file scope array. There is exactly one list of drawables in the program.
+
+### add
+
+```c
+		static void add( struct grid_position grid_position, const struct drawable* const toadd ){
+			this(&drawables)->append((
+				(struct drawable_in_grid[]){ { {grid_position}, {*toadd} } }
+			));
+		}
+```
+
+The compound literal builds a one element array of `drawable_in_grid` right there in the argument, and `append` is the macro from the include side of `array.c`, so it becomes `append( array_of( ... ) )`- the literal is measured for element count and element size, copied to the heap, and appended. `this(&drawables)` first stores the array we are operating on so that the append we call actually lands on the right object.
+
+`*toadd` copies the drawable by value into the element- but `object` inside it still points at the original box on the heap. So the collection owns a copy of the *vtable and the self pointer*, while all of the box' actual state stays where `box.new` put it. That is why `console.add_box` can pass `&box.new(...)->drawable` and then forget about the box entirely.
+
+### draw_all
+
+```c
+		static void draw_all( CHAR_INFO* const consolebuffer, int16_t width, int16_t height ){
+			if( this(&drawables)->element_count == 0 ){ return; }
+			for( int16_t row = 0; row <= height; row++ ){
+				for( uint32_t i = 0; i < this(&drawables)->element_count; i++ ){
+					if( row >= this(&drawables)->value[i].y ){
+						this(&drawables)->value[i].draw(
+							this(&drawables)->value[i].drawable.object,
+							&consolebuffer[ (width * row) + this(&drawables)->value[i].x ],
+							row - this(&drawables)->value[i].y
+						);
+					}
+				}
+			}
+		}
+```
+
+Row major, one scanline at a time: for every row of the console we ask every object that has already started to contribute its share of that row. The three arguments are exactly the three pieces of the contract:
+
+- `value[i].drawable.object`- the object pointer we stored in `box.new`, handed back as the `this`.
+- `&consolebuffer[ (width * row) + x ]`- not the start of the buffer, but the start of *that object's* row. The console buffer is one flat array, so `width * row` picks the row and `+ x` slides right to the object's column. Everything the drawable writes at index 0 lands where it should, and the drawable never has to know the console width.
+- `row - y`- the row number translated into the object's own coordinates. The box asks `rownr == 0` for its top border and `rownr == this->height` for its bottom one, and never has to think about screen coordinates at all.
+
+The `row >= y` test is what makes a box that starts further down simply not participate until we reach it, and the box returns early on `rownr > this->height` once we have gone past its bottom.
+
+Drawing in element order means later objects overwrite earlier ones where they overlap- a painter's algorithm, with insertion order as the z order. In `main.c` boxes are added continuously by the timer, so the newest box is always the one on top.
+
+The collection never clears anything. That is `console.c`'s job- its own tick memsets a fresh `consoleBuffer`, calls `draw_all` into it, and hands the finished buffer to `WriteConsoleOutputW` in a single call. So there is no flicker and no partial frame: every frame is composed completely before any of it is shown.
+
+### What the pattern buys
+
+`drawables.c` includes `drawable.c` and nothing else in its public part. It has never heard of a box, a string or a console. `box.c` implements draw and never hears about the collection. `console.c` is the only file that knows both exist, and it is the one that wires them together in `add_box`.
+
+Adding a second kind of drawable- a line, a menu, a progress bar- means writing one more component that puts `drawable;` first in its interface and hands `&thing.new(...)->drawable` to `drawable_objects.add`. Nothing in `drawables.c` changes, and nothing in it needs to be told the new type exists.

--- a/07-string.c.md
+++ b/07-string.c.md
@@ -1,0 +1,117 @@
+### string.c
+
+A value type string, and the machinery to build one out of anything.
+
+The first thing to notice is that this file is inverted compared to every other component:
+
+```c
+#include "stdafx.h"
+#if __INCLUDE_LEVEL__  != 0
+#	ifndef charbuf
+#		define charbuf charbuf
+```
+
+Everywhere else I write `#if __INCLUDE_LEVEL__ == 0` to mark the private part. Here the whole file is wrapped in the opposite test, so `string.c` only exists when it is *included*. Compile it directly and you get an empty translation unit.
+
+That is intentional- there is nothing here that needs to exist once in the program. Every function is `static inline` and every type is a value type, so each file that includes it gets its own copy and the compiler is free to inline all of it away. There is no state to own, so there is no reason to have a private part at all. `string.c` is closer to a header than to a component, and the include level test says so out loud.
+
+### The string itself
+
+```c
+		struct nstring{ char array[ ARRSIZE ]; };
+		struct wstring{ wchar_t array[ ARRSIZE/2 ]; };
+		struct string{
+			union{
+				char array[ ARRSIZE ];
+				struct nstring nstring;
+				struct wstring wstring;
+			} ;
+		};
+```
+
+`ARRSIZE` is 512, from `stdafx.h`. A `struct string` is 512 bytes and nothing else- no pointer, no length, no allocation. The union gives three views of the same bytes: as a plain `char` array, as a narrow string, or as 256 wide characters, which is the same 512 bytes again.
+
+This is the whole reason strings can be passed and returned by value everywhere. In `main.c`:
+
+```c
+	static struct string boxname( int16_t x, int16_t y, int count ){
+		return str(str(str(x),",",str(y)),"-",str(count));
+	}
+```
+
+That returns a string by value, out of a function, with no allocation and nothing to free. And `box_arguments` can hold a `struct wstring text` as a member rather than a pointer, which means a box owns its own text outright- there is no dangling pointer to worry about when the caller's buffer goes away, and `box.new` copying `arguments` into the box copies the text with it.
+
+The cost is that every string is 512 bytes whether it holds five characters or five hundred, and that nothing here bounds checks- `string()` uses `strcpy` and the concatenating overloads use `strcat`. For box titles built out of a few numbers that is a trade I am happy with, but it is a deliberate trade and not an oversight.
+
+`wstring()` walks the narrow string and widens each character into the wide view. That is the conversion `console.add_box` does when it hands text to the box, because the console buffer is `CHAR_INFO` and wants `WCHAR`.
+
+### str, and letting the type pick the format string
+
+This is the part I actually wanted out of this file. In c you normally have to tell `printf` what you are giving it, and if you get the format specifier wrong nothing tells you until it misbehaves at runtime. With `overload` we can make the type choose:
+
+```c
+#		define MAKE_STR( TYPE, FSTR )static overload inline struct string str( TYPE in ){ \
+			struct string buffer; \
+			snprintf( buffer.array, ARRSIZE, FSTR, in ); \
+			return buffer; \
+		}
+#		define FSTR( $ )\
+				$(_Bool              , "%d"   ) \
+				$(char               , "%c"   ) \
+				$(signed char        , "%hhd" ) \
+				...
+				$(void*				 , "%p"   )
+				FSTR( MAKE_STR )
+```
+
+Same `$` pattern as the `TYPES` list in `array.c`- `FSTR` is a list that applies whatever macro you hand it to every entry, and here we hand it `MAKE_STR` to generate one `str` overload per builtin type, each one carrying the correct format specifier for its own type.
+
+The result is that `str(x)` is correct for any scalar in the language, and the format string never appears at a call site. You cannot pass an `int` where the format says `%s`, because you never write the format at all- the compiler picks the overload by the argument type and the format comes attached to it.
+
+### Concatenation by overload
+
+```c
+				inline static overload struct string str( struct string a, struct string b ){
+					struct string buffer={0};
+					strcat( buffer.array, a.array );
+					strcat( buffer.array, b.array );
+					return buffer;
+				}
+```
+
+Then the same for `char*` and `struct string` in every combination, and the three argument versions just fold into the two argument ones:
+
+```c
+				inline static overload struct string str( char* a, struct string b, char* c ){ return str( str( str(a), str(b) ), str(c) ); }
+```
+
+So `str` is simultaneously "convert this to a string" and "join these into a string", chosen by arity and type. That is what lets `boxname` in `main.c` read as a single expression mixing two `int16_t`, an `int` and two literals, without a single format string or temporary buffer.
+
+### CAT and STR
+
+```c
+#	define _CAT($0,$1,...,$512,...) $0##$1##$2##...##$512
+#	define CAT(...)_CAT( __VA_ARGS__,,,,,, ...512 empty arguments... )
+```
+
+`CAT` pastes up to 512 tokens into one identifier. It works by padding the call with a long tail of empty arguments so `_CAT` always receives a full parameter list, and pasting an empty argument contributes nothing- so `CAT(a,b)` and `CAT(a,b,c,d)` both come out as just the tokens joined.
+
+It looks absurd written out, but it is generated once and never read again. `test.c` is what needs it, to manufacture a unique function name per test out of `__COUNTER__`.
+
+```c
+#	define _STR( ... )#__VA_ARGS__
+#	define STR( ... )_STR( __VA_ARGS__ )
+```
+
+The usual two step stringize. Going through `_STR` means the argument gets macro expanded before it is turned into text, which is what makes `assert` able to print the expression that failed as the reader wrote it.
+
+### log
+
+```c
+#	define logline( ... ) ( print(str(__FILE__)), print("."), print(str(__func__)), print(": "), xprint_(__VA_ARGS__,"\n",,,,,, ) )
+#	define xprint_b( ... ) __VA_OPT__(  logline( str(__VA_ARGS__) ) , )
+```
+
+`log` takes up to twelve items of any type, runs each through `str` and prints them with the file and function name in front. `__VA_OPT__` is what makes the unused slots disappear- an empty argument expands to nothing at all rather than to an empty print.
+
+Because everything goes through `str`, you log values, not formatted text- there is no format string to keep in sync with the arguments.

--- a/08-timer.c.md
+++ b/08-timer.c.md
@@ -1,0 +1,92 @@
+### timer.c
+
+The component that turns a function into something that runs on its own thread at a fixed rate. Both threads in this program come from here.
+
+```c
+#ifndef timer
+#	define timer timer
+	typedef uint32_t ms;
+	typedef struct timer{
+		HANDLE(*timer_function)( struct timer* );
+		HANDLE threadhandle;
+		unsigned long tickrate;
+		bool active;
+	}*timer;
+	typedef typeof(((timer)0)->timer_function) timer_function;
+	extern struct{
+		HANDLE(*new)( timer_function receiver, ms tickrate );
+	}timers;
+```
+
+Two things in the typedefs worth pointing out.
+
+`typedef struct timer{ ... }*timer;` typedefs the *pointer*, not the struct. So `timer` as a type name means "a pointer to a timer", and the private functions take `timer this` and get a pointer. The struct tag `struct timer` still names the struct itself, which is what the public callback signature uses.
+
+`typedef typeof(((timer)0)->timer_function) timer_function;` derives the callback type from the member rather than writing the signature out a second time. `(timer)0` is a null pointer that is never dereferenced- `typeof` only looks at the type, so nothing happens at runtime. It is the same instinct as `typeof(box) box` at the bottom of `box.c`: state a type once, and refer back to it everywhere else. Change the callback signature in the struct and everything that uses `timer_function` follows automatically.
+
+`ms` exists so a tickrate cannot be quietly confused with any other number at a call site- `timers.new( tick, (ms){1} )` in `console.c` says what the 1 means.
+
+### One function that is both the starter and the loop
+
+```c
+		HANDLE tick( timer this ){
+			if( this->active ){
+				if( this->threadhandle == 0 ){
+					typedef union transparent{
+						typeof(&tick) tick;
+						LPTHREAD_START_ROUTINE thread;
+					}thread_function;
+					return this->threadhandle = CreateThread( NULL, 0xffffff, ((thread_function)&tick).thread, this, 0, 0 );
+				}
+				while( this->active ){
+					WaitForSingleObject( this->threadhandle, this->tickrate );
+					this->timer_function( this );
+				}
+				free(this);
+			}
+			return 0;
+		}
+```
+
+`tick` is called twice for every timer, and does something different each time.
+
+The first call comes from `new`, on the calling thread, with `threadhandle` still zero. It creates a thread whose start routine is `tick` itself, passing `this` as the thread parameter, stores the handle and returns it.
+
+The second call is that new thread starting up. Now `threadhandle` is set, so it falls through to the loop and stays there.
+
+The transparent union is the same trick as `box.new` uses for `draw`. `CreateThread` demands an `LPTHREAD_START_ROUTINE`, and `tick` is a `HANDLE(*)(struct timer*)`. Rather than casting the function pointer- which is the normal way and throws away all type checking- I declare a union whose members are both signatures and let the transparent attribute accept either. Same effect as a cast at the machine level, but the compiler still knows what the two types are.
+
+`0xffffff` is a 16 megabyte stack, and that is not arbitrary: `console.c`'s tick declares its whole console buffer as a variable length array on the stack every frame. That buffer is one `CHAR_INFO` per cell for a maximized console, so the thread needs room for it.
+
+### The wait is the sleep
+
+```c
+					WaitForSingleObject( this->threadhandle, this->tickrate );
+```
+
+The thread waits on its own thread handle with a timeout. A thread handle only becomes signalled when the thread exits, and this thread is the one doing the waiting, so it can never be signalled here- the wait always runs out the full timeout. So this is a sleep of `tickrate` milliseconds, written as a wait.
+
+Then `timer_function( this )` is called, and around again. The timer passes itself into the callback, which is the same "c has no thiscall, so pass the object explicitly" compensation as `this()` in `array.c` and `object` in the drawable- the callback gets a handle on its own timer if it wants it.
+
+When `active` goes false the loop ends and the timer frees itself. Nothing in the public interface sets `active` to false though- there is no stop, so in this program the timers run until the process ends. If I wanted to be able to stop one, that is the one member that would need to be reachable, and the natural way would be to put a `stop` in the `timers` vtable rather than exposing the flag.
+
+### Two timers, two threads
+
+`main.c`:
+
+```c
+	int main( int argc, char* argv[] ){
+		timers.new( drawtick, 2 );
+		console.run();
+	}
+```
+
+and inside `console.run`:
+
+```c
+			WaitForSingleObject( timers.new( tick, (ms){1} ), INFINITE );
+```
+
+So there are two timers. `drawtick` runs every 2 ms and adds a box; `console.c`'s `tick` runs every 1 ms and paints the whole collection. The main thread creates both and then parks on the render thread's handle forever- and here the wait *does* mean a wait, because the main thread is waiting on a handle that is not its own.
+
+That is the shape the introduction described: one loop producing boxes, another iterating the collection and drawing them, with `timer.c` being the only file that knows a thread was ever involved.

--- a/09-console.c.md
+++ b/09-console.c.md
@@ -1,0 +1,123 @@
+### console.c
+
+The composition root. Every other component has been written without knowing what it would be used with- `box.c` has never heard of the collection, `drawables.c` has never heard of a box, `timer.c` has never heard of either. This is the file where they meet.
+
+```c
+	extern const struct console{
+		void(*run)( void );
+		void(*add_box)(
+			struct grid_position grid_position,
+			int16_t height,
+			int16_t width,
+			struct string boxtext,
+			enum text_placement text_placement ,
+			enum console_color color
+		);
+		struct console_size{
+			int16_t rows;
+			int16_t cols;
+		}(*get_size)( void );
+	}console;
+```
+
+Three functions, and that is the entire surface `main.c` gets.
+
+`struct console_size` is declared inline in the return type of `get_size`. It is still a normal named type afterwards, so `main.c` can hold one, but declaring it where it is used keeps it next to the only function that produces it.
+
+Notice what `add_box` takes: a position, a size, a string, and two enums. Those enums and `struct grid_position` come from `box.c` and `drawables.c`, which `console.c` includes in its public part- which is exactly the rule from the box chapter, that if a public function takes something, the type has to be in the public part so one include is enough to use the component. `main.c` includes `console.c` and gets everything it needs to call `add_box`, including `top` and `bottom` and the colour names, without including anything else.
+
+And notice what it does *not* take: a box. `main.c` cannot make a box, cannot hold one, and has no way to reach one after it is added. It asks the console for a box at a position and the console handles the rest.
+
+### rows and cols
+
+```c
+		static struct console_size get_size(void){
+			CONSOLE_SCREEN_BUFFER_INFOEX sbInfo={ .cbSize = sizeof(sbInfo) };
+			GetConsoleScreenBufferInfoEx( GetStdHandle(STD_OUTPUT_HANDLE), &sbInfo );
+			return (struct console_size){ .rows = sbInfo.dwMaximumWindowSize.X ,.cols =  sbInfo.dwMaximumWindowSize.Y };
+		}
+```
+
+One thing to be aware of when reading the rest of the file: `rows` is the X extent and `cols` is the Y extent, which is the opposite of what those two words usually suggest. It is consistent everywhere- `draw_all( consoleBuffer, get_size().rows, get_size().cols )` passes them into `draw_all`'s `width` and `height` in that order- but read `rows` as "how wide" and `cols` as "how tall" and the arithmetic will make sense.
+
+### One frame at a time
+
+```c
+		static HANDLE tick( struct timer* this ){
+			CHAR_INFO consoleBuffer[ (get_size().rows+1) * (get_size().cols+1) ];
+			memset( consoleBuffer, 0, sizeof(consoleBuffer) );
+			drawable_objects.draw_all( consoleBuffer, get_size().rows, get_size().cols );
+			WriteConsoleOutputW(
+				GetStdHandle( STD_OUTPUT_HANDLE ),
+				consoleBuffer,
+				(COORD){ get_size().rows, get_size().cols },
+				(COORD){ 0, 0 },
+				&(SMALL_RECT){ 0, 0, get_size().rows , get_size().cols  }
+			);
+			return this;
+		}
+```
+
+The buffer is a variable length array sized from the console every frame, so resizing the window is picked up on the next tick with no reallocation and nothing to free. It lives on the stack, which is why `timer.c` asks `CreateThread` for a 16 megabyte stack.
+
+The order matters and is the whole point of drawing into a buffer rather than to the console: clear, let every drawable contribute, then hand the finished frame over in a single `WriteConsoleOutputW`. Nothing is ever shown half drawn, and there is no flicker, because the console is never in an intermediate state- it goes from one complete frame to the next.
+
+This is also the only place that decides what a frame *is*. `draw_all` does not clear and does not present; it only composes. If I wanted to draw into two buffers alternately, or to something that is not a console at all, this function is the only one that would change.
+
+### run
+
+```c
+		static void run(void){
+			is_drawing = true;
+			SetWindowPlacement( GetConsoleWindow(), &(WINDOWPLACEMENT){ sizeof(WINDOWPLACEMENT), .showCmd = SW_SHOWMAXIMIZED } );
+			SetConsoleOutputCP(65001);
+			WaitForSingleObject( timers.new( tick, (ms){1} ), INFINITE );
+		}
+```
+
+Maximize the window, switch the output code page to 65001 so the box drawing characters `┌ ─ ┐ │ └ ┘` in `box.c` come out as themselves, start a 1 ms timer on `tick`, and block on it forever. `run` never returns, which is why `main` has nothing after it.
+
+### add_box, where the wiring happens
+
+```c
+		static void add_box(
+			struct grid_position grid_position, ... ){
+  			drawable_objects.add(
+				grid_position,
+				&box.new(
+					(struct box_arguments){
+						.text = wstring(boxtext),
+						.color = console_color,
+						.grid_size = { .width = grid_width, .height = grid_height },
+						.text_placement = text_placement
+					}
+				)->drawable
+			);
+		}
+```
+
+This is the composition, and it is a single expression.
+
+`box.new` returns a `struct box_interface*`- the public face of a box, with the private `struct box` behind it that nobody out here can see. `->drawable` reaches the drawable that `box_interface` starts with, and its address is what the collection wants. So the box is created, immediately handed to the collection, and the pointer is never stored anywhere else. Nothing after this line can reach that box except through `draw_all`.
+
+`wstring(boxtext)` is the widening conversion from `string.c`, and because `struct wstring` is a value the box gets its own copy of the text- `main.c` built that string on its stack in `boxname` and can let it go.
+
+The four things this function knows: that a box exists, that it can be drawn, that the collection accepts drawables, and that text needs widening. That is the entire coupling in this program, and it is confined to one function.
+
+```c
+		typeof(console) console = {
+			.run = run,
+			.add_box = add_box,
+			.get_size = get_size
+		};
+```
+
+The vtable filled at compile time, with `typeof(console)` picking up the type- including the `const`- from the extern declaration in the public part.
+
+### A note on the two threads
+
+`drawtick` on one thread calls `add_box`, which appends to the collection. `tick` on the other thread walks that same collection in `draw_all`. There is no lock between them, and `append` reallocates and frees the old buffer, so this is racy in principle- the draw thread can be walking a buffer that the add thread is about to free.
+
+It survives here because the tick rates are slow in machine terms and the window between the two is small, but it survives by luck rather than by design. The place to fix it would be in `drawables.c`, since the collection is the shared thing and both threads only reach it through `add` and `draw_all`.
+
+One detail that is *not* luck: the `last` pointer inside `this()` in `array.c` is declared `static __thread`. Each thread gets its own, so the add thread calling `this(&drawables)` cannot disturb what the draw thread has stored. Without that one keyword the two threads would overwrite each other's notion of which array is being operated on.

--- a/10-test.c.md
+++ b/10-test.c.md
@@ -1,0 +1,109 @@
+### test.c
+
+A unit test component that costs nothing when it is not enabled, needs no registration list, and needs no test runner.
+
+```c
+#ifndef testarrayof
+#	define testarrayof testarrayof
+#	include "stdafx.h"
+#	include "array.c"
+#	include "string.c"
+#	if __INCLUDE_LEVEL__ == 0
+#		ifdef TEST
+```
+
+Same include level fence as everywhere else, with a second condition on top: the tests only exist when the file is compiled directly *and* `TEST` is defined. Two switches, so tests never leak into a build that did not ask for them.
+
+### Tests that register themselves
+
+```c
+#			define run_test_print(...)	__attribute__((constructor(__COUNTER__+1000))) static inline void CAT(autorun,__COUNTER__,__VA_ARGS__)(void){\
+											puts("Running test "STR(__VA_ARGS__)":");\
+											void CAT(test,__VA_ARGS__)(void);\
+											CAT(test,__VA_ARGS__)();\
+										}
+#			define test(...)			run_test_print(__VA_ARGS__)\
+										static inline void CAT(test,__VA_ARGS__)(void)
+```
+
+`test(name)` expands into two things: a constructor function, and the opening of a definition of `testname`. The braces the reader writes after `test(array)` become that function's body. So this:
+
+```c
+		test(array){
+			...
+		}
+```
+
+is a complete function definition plus a constructor that calls it, out of what reads like a block with a label on it.
+
+`__attribute__((constructor))` makes a function run before `main`. The priority argument controls the order, and `__COUNTER__+1000` gives each test a number one higher than the last, so the tests run in the order they appear in the file. `__COUNTER__` increments every time it is read, which is also why the generated `autorun` name is unique without me having to name it- and that is what `string.c`'s `CAT` is for, pasting `autorun`, the counter value and the test name into one identifier.
+
+The result is that there is no list of tests anywhere. Writing `test(something)` is the whole registration. Nothing has to be updated when a test is added, and there is no way to add a test and forget to run it.
+
+The forward declaration of `CAT(test,__VA_ARGS__)` inside the constructor is what lets the constructor come first and still call a function that is defined afterwards.
+
+### Compiling to nothing
+
+```c
+#		else
+#			define test(...)__if_exists(__notexisting)
+#			define assert(...)
+#		endif
+```
+
+Without `TEST`, `assert` becomes empty and `test` becomes `__if_exists(__notexisting)`- a block that is only compiled if a symbol by that name exists, and nothing is called `__notexisting`. So the braces following `test(array)` are swallowed whole and the test body never reaches the compiler. Not compiled out with `#if`, but discarded by the language, which means the tests can live in a normal source file with no preprocessor scaffolding wrapped around each one.
+
+### assert
+
+```c
+#			define assert(...)({ auto result = (__VA_ARGS__); if( result == 0 ){ print( str(STR(__VA_ARGS__)" failed")); __debugbreak();}})
+```
+
+A statement expression, so the condition is evaluated exactly once into `result` no matter how many times the macro body mentions it- a plain macro that used `__VA_ARGS__` twice would run a function call in the condition twice.
+
+On failure it prints the expression as written, using `STR` from `string.c`, and then `__debugbreak()`- it breaks into the debugger at the failing line with the whole state still live, rather than aborting and leaving you with a message. `str` and `print` are the same ones from `string.c`, so an assert message costs no format string either.
+
+### Testing the drawable interface
+
+```c
+		void testdraw( struct drawable* this, CHAR_INFO* const consoleBuffer, int16_t  ){
+			assert(this);
+			assert(consoleBuffer);
+		}
+
+		test(drawable_objects){
+			struct drawtest{
+				drawable;
+			}obj = {{ .object = &obj.drawable, .draw = &testdraw }};
+
+			drawable_objects.add(
+				(struct grid_position){0,0},
+				obj.object
+			);
+			assert(
+				drawable_objects.draw_all( &(CHAR_INFO){}, 2, 2 ),
+				1
+			);
+		}
+```
+
+This is worth reading as documentation of the interface as much as a test, because it shows the whole cost of implementing a drawable: one member `drawable;` and one initializer pointing `object` at itself. No allocation, no constructor, no interface registration- `struct drawtest` is a local on the stack and the collection accepts it exactly like a box.
+
+It also demonstrates the thing the box chapter was about, from the other side. `testdraw` takes a `struct drawable*` and the box's `draw` takes a `struct box*`, and both are valid `draw` implementations, because what the interface stores is the transparent union's worth of signatures rather than one fixed one.
+
+The third parameter of `testdraw` is unnamed- it is the row number, which this implementation does not care about, and leaving the name off says that rather than leaving an unused variable behind.
+
+One honest note about that last assert: `draw_all` returns void, and `assert` evaluates `(__VA_ARGS__)`, so `assert( draw_all(...), 1 )` is a comma expression that always comes out as 1. It checks that the call is reachable and does not crash, not that it drew anything. To assert on the result you would need the drawable to record that it was called- a counter in `struct drawtest` that `testdraw` increments, checked afterwards.
+
+### The array tests
+
+```c
+		test(array){
+			auto memory = array_of("jonas");
+			assert( strcmp( this(memory)->append( "jonas" )->value, "jonasjonas" ) == 0 );
+			...
+```
+
+These are the ones shown in the array chapter. The char case exists specifically to prove the special cased `append` for `array_of_char` overwrote the terminating null instead of leaving it in the middle- `"jonasjonas"` and not `"jonas\0jonas"`. The int case then proves the general append kept every element intact, and that the two are dispatched apart correctly by type.
+
+`auto` here is `__auto_type` from `stdafx.h`. The array types are generated per contained type and named `struct array_of_int` and so on, so `auto` saves writing out a name that the macro produced.


### PR DESCRIPTION
This PR completes the walkthrough series, adding a chapter for every source file that was still undocumented.

## Summary

Five new documentation files, covering six source files. With these, chapters 01–10 document the entire codebase; no source code is changed.

## Documentation Added

- **06-drawables.c.md**: Covers `drawable.c` and `drawables.c` together. `drawable.c` is the one file with no private section at all — it is pure interface, so there is nothing to implement. Explains the `object` self-pointer as the compensation for c having no thiscall convention, why `grid_position` belongs to the collection rather than to the box, how the include cycle between `array.c` and `drawables.c` terminates on the `#ifndef` guards, and how `draw_all` translates screen coordinates into each object's own row number and buffer offset so a drawable never learns where it is on screen.

- **07-string.c.md**: The fixed-size value-type string, and the `str()` overload set. Notes that this file inverts the usual fence — it is wrapped in `__INCLUDE_LEVEL__ != 0`, so it exists only when included and compiles to an empty translation unit on its own. Explains how the `FSTR`/`MAKE_STR` pair generates one overload per builtin type so the argument's type carries its own format specifier, why passing strings by value means a box owns its text outright, and what `CAT` and `STR` are for.

- **08-timer.c.md**: The timer component. Covers the typedef naming the pointer rather than the struct, deriving the callback type from the member with `typeof(((timer)0)->timer_function)` instead of restating the signature, the dual-purpose `tick()` that is both thread starter and thread body, the transparent union standing in for a function-pointer cast to `LPTHREAD_START_ROUTINE`, and why the 16 MB thread stack is required by the per-frame buffer in `console.c`.

- **09-console.c.md**: The composition root. `add_box` is the only function in the program that knows both a box and the collection exist, and it is a single expression. Documents the frame pipeline (clear → compose → present in one `WriteConsoleOutputW`) and that `rows` is the X extent while `cols` is the Y extent, which is the reverse of what the names suggest.

- **10-test.c.md**: The self-registering test component — `__attribute__((constructor(__COUNTER__+1000)))` means there is no test list anywhere, and `__if_exists(__notexisting)` discards test bodies entirely when `TEST` is undefined. Also covers the single-evaluation `assert` and why the drawable test doubles as documentation of how little it costs to implement the interface.

## Key Design Patterns Explained

- Transparent unions replacing casts — at a function-pointer assignment (`box.new`'s `draw`, `CreateThread`'s start routine) and in argument types, keeping type information the compiler can check where a cast would throw it away. The drawable interface does have a vtable; what the union removes is the cast, not the vtable.
- Include-level guards separating public interface from private implementation, and the two files that deliberately break the pattern — `drawable.c` (interface only, no private part) and `string.c` (include-only, no compiled part).
- Value-type strings passed and returned without allocation or ownership.
- Type-driven overload selection, both for format specifiers in `str()` and for the per-type `append` in `array.c`.
- Self-registering tests via constructor priorities, costing nothing when not enabled.
- Buffer-based rendering: a frame is composed completely before it is presented in a single call, so nothing is ever shown half-drawn.

## Notes recorded in the chapters

Three sharp edges are documented as tradeoffs rather than glossed over:

- `string.c` uses `strcpy`/`strcat` into fixed 512-byte buffers with no bounds check.
- `add_box` and `draw_all` touch the same collection from two threads with no lock, and `append` frees the old buffer — buffer-based rendering prevents tearing within a frame, but it does not make the collection itself thread-safe. The `static __thread` on `last` in `array.c`'s `this()` is what keeps the two threads from stomping each other's state.
- `assert( drawable_objects.draw_all(...), 1 )` in `test.c` is a comma expression that always evaluates to 1, since `draw_all` returns void — it asserts reachability, not behaviour.

The chapters use fenced code blocks rather than the screenshots used in chapters 01–05; images can be swapped in wherever preferred.

https://claude.ai/code/session_01BBLhzjWgfeSC7gfYw3eowe